### PR TITLE
Acquire version info with using platform details.

### DIFF
--- a/lib/mixlib/install/artifact_info.rb
+++ b/lib/mixlib/install/artifact_info.rb
@@ -24,15 +24,40 @@ module Mixlib
       attr_accessor :sha256
       attr_accessor :version
 
+      attr_accessor :platform
+      attr_accessor :platform_version
+      attr_accessor :architecture
+
       def initialize(data)
         @url = data[:url]
         @md5 = data[:md5]
         @sha256 = data[:sha256]
         @version = data[:version]
+        @platform = data[:platform]
+        @platform_version = data[:platform_version]
+        @architecture = data[:architecture]
       end
 
-      def self.from_json(json)
-        ArtifactInfo.new(JSON.parse(json, symbolize_names: true))
+      def self.from_json(json, platform_info)
+        ArtifactInfo.new(JSON.parse(json, symbolize_names: true).merge(platform_info))
+      end
+
+      def self.from_metadata_map(json)
+        artifacts = []
+
+        JSON.parse(json, symbolize_names: true).each do |p, p_data|
+          p_data.each do |pv, pv_data|
+            pv_data.each do |m, metadata|
+              artifacts << ArtifactInfo.new(metadata.merge(
+                platform: p,
+                platform_version: pv,
+                architecture: m
+              ))
+            end
+          end
+        end
+
+        artifacts
       end
 
       def to_hash
@@ -40,7 +65,10 @@ module Mixlib
           url: url,
           md5: md5,
           sha256: sha256,
-          version: version
+          version: version,
+          platform: platform,
+          platform_version: platform_version,
+          architecture: architecture
         }
       end
     end

--- a/lib/mixlib/install/backend/omnitruck.rb
+++ b/lib/mixlib/install/backend/omnitruck.rb
@@ -54,12 +54,12 @@ module Mixlib
 
         private
 
-        def omnitruck_get(endpoint, parameters)
+        def omnitruck_get(resource, parameters)
           uri = URI.parse(OMNITRUCK_ENDPOINT)
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = (uri.scheme == "https")
 
-          path = "/#{options.channel}/#{options.product_name}/#{endpoint}"
+          path = "/#{options.channel}/#{options.product_name}/#{resource}"
           full_path = [path, URI.encode_www_form(parameters)].join("?")
           request = Net::HTTP::Get.new(full_path)
           request["Accept"] = "application/json"

--- a/lib/mixlib/install/backend/omnitruck.rb
+++ b/lib/mixlib/install/backend/omnitruck.rb
@@ -24,6 +24,7 @@ module Mixlib
   class Install
     class Backend
       class Omnitruck
+        OMNITRUCK_ENDPOINT = "https://omnitruck.chef.io"
 
         attr_accessor :options
 
@@ -32,20 +33,33 @@ module Mixlib
         end
 
         def info
-          parameters = {
-            p: options.platform,
-            pv: options.platform_version,
-            m: options.architecture,
-            v: options.product_version
-          }
+          # If we are querying a single platform we need to call metadata
+          # endpoint otherwise we need to call versions endpoint in omnitruck
+          if options.platform
+            build = omnitruck_get("metadata", p: options.platform,
+                                              pv: options.platform_version,
+                                              m: options.architecture,
+                                              v: options.product_version
+                                 )
+            ArtifactInfo.from_json(build,
+                                   platform: options.platform,
+                                   platform_version: options.platform_version,
+                                   architecture: options.architecture
+            )
+          else
+            builds = omnitruck_get("versions", v: options.product_version)
+            ArtifactInfo.from_metadata_map(builds)
+          end
+        end
 
-          endpoint = "https://omnitruck.chef.io"
+        private
 
-          uri = URI.parse(endpoint)
+        def omnitruck_get(endpoint, parameters)
+          uri = URI.parse(OMNITRUCK_ENDPOINT)
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = (uri.scheme == "https")
 
-          path = "/#{options.channel}/#{options.product_name}/metadata"
+          path = "/#{options.channel}/#{options.product_name}/#{endpoint}"
           full_path = [path, URI.encode_www_form(parameters)].join("?")
           request = Net::HTTP::Get.new(full_path)
           request["Accept"] = "application/json"
@@ -54,7 +68,7 @@ module Mixlib
 
           # Raise if response is not 2XX
           res.value
-          ArtifactInfo.from_json(res.body)
+          res.body
         end
       end
     end

--- a/spec/mixlib/install/backend_spec.rb
+++ b/spec/mixlib/install/backend_spec.rb
@@ -299,8 +299,7 @@ context "Mixlib::Install::Backend" do
           let(:product_version) { "12.4.3+20151006083011" }
           let(:expected_version) { "12.4.3+20151006083011" }
 
-          # This test is currently disabled due to an omnitruck issue.
-          # it_behaves_like "the right artifact list info"
+          it_behaves_like "the right artifact list info"
         end
 
         context "with a major.minor.patch product version" do

--- a/spec/mixlib/install/backend_spec.rb
+++ b/spec/mixlib/install/backend_spec.rb
@@ -27,18 +27,18 @@ context "Mixlib::Install::Backend" do
   let(:platform_version) { nil }
   let(:architecture) { nil }
 
-  shared_examples_for "the right artifact info" do
-    let(:info) {
-      Mixlib::Install.new(
-        channel: channel,
-        product_name: product_name,
-        product_version: product_version,
-        platform: platform,
-        platform_version: platform_version,
-        architecture: architecture
-      ).artifact_info
-    }
+  let(:info) {
+    Mixlib::Install.new(
+      channel: channel,
+      product_name: product_name,
+      product_version: product_version,
+      platform: platform,
+      platform_version: platform_version,
+      architecture: architecture
+    ).artifact_info
+  }
 
+  shared_examples_for "the right artifact info" do
     it "gives the right url artifact info" do
       if !expected_info.key?(:url)
         expect(info.url).to match "http"
@@ -68,6 +68,58 @@ context "Mixlib::Install::Backend" do
         expect(info.version).to match(/\d.\d.\d/)
       else
         expect(info.version).to match expected_info[:version]
+      end
+    end
+
+    it "has the right platform" do
+      expect(info.platform).to eq(platform)
+    end
+
+    it "has the right platform_version" do
+      expect(info.platform_version).to eq(platform_version)
+    end
+
+    it "has the right architecture" do
+      expect(info.architecture).to eq(architecture)
+    end
+  end
+
+  shared_examples_for "the right artifact list info" do
+    it "has the correct number of platforms" do
+      # Currently we have 8 platforms in stable and 7 platforms in current.
+      # We can add more in the future
+      expect(info.map(&:platform).uniq.length).to be >= 7
+
+      info.each do |artifact_info|
+        expect(artifact_info).to be_a(Mixlib::Install::ArtifactInfo)
+      end
+    end
+
+    it "has the right version for artifacts" do
+      info.each do |artifact_info|
+        if expected_version.is_a? String
+          expect(artifact_info.version).to eq(expected_version)
+        else
+          expect(artifact_info.version).to match(expected_version)
+        end
+      end
+    end
+
+    it "has correctly formed url" do
+      info.each do |artifact_info|
+        expect(artifact_info.url).to match "http"
+      end
+    end
+
+    it "has correctly formed sha256" do
+      info.each do |artifact_info|
+        expect(artifact_info.sha256).to match(/^[0-9a-f]{64}$/)
+      end
+    end
+
+    it "has correctly formed md5 for artifacts" do
+      info.each do |artifact_info|
+        expect(artifact_info.md5).to match(/^[0-9a-f]{32}$/)
       end
     end
   end
@@ -144,6 +196,36 @@ context "Mixlib::Install::Backend" do
           it_behaves_like "the right artifact info"
         end
       end
+
+      context "when p, pv and m are not present" do
+        context "with a full product version" do
+          let(:product_version) { "12.4.3" }
+          let(:expected_version) { "12.4.3" }
+
+          it_behaves_like "the right artifact list info"
+        end
+
+        context "with a major.minor product version" do
+          let(:product_version) { "12.1" }
+          let(:expected_version) { "12.1.2" }
+
+          it_behaves_like "the right artifact list info"
+        end
+
+        context "with a major product version" do
+          let(:product_version) { "12" }
+          let(:expected_version) { /^12.\d.\d/ }
+
+          it_behaves_like "the right artifact list info"
+        end
+
+        context "with latest version keyword" do
+          let(:product_version) { "latest" }
+          let(:expected_version) { /\d.\d.\d/ }
+
+          it_behaves_like "the right artifact list info"
+        end
+      end
     end
 
     context "for current" do
@@ -209,6 +291,44 @@ context "Mixlib::Install::Backend" do
           let(:expected_info) { {} }
 
           it_behaves_like "the right artifact info"
+        end
+      end
+
+      context "when p, pv and m are not present" do
+        context "with a full product version" do
+          let(:product_version) { "12.4.3+20151006083011" }
+          let(:expected_version) { "12.4.3+20151006083011" }
+
+          # This test is currently disabled due to an omnitruck issue.
+          # it_behaves_like "the right artifact list info"
+        end
+
+        context "with a major.minor.patch product version" do
+          let(:product_version) { "12.4.3" }
+          let(:expected_version) { /^12.4.3\+[0-9]{14}$/ }
+
+          it_behaves_like "the right artifact list info"
+        end
+
+        context "with a major.minor product version" do
+          let(:product_version) { "12.4" }
+          let(:expected_version) { /^12.4.\d\+[0-9]{14}$/ }
+
+          it_behaves_like "the right artifact list info"
+        end
+
+        context "with a major product version" do
+          let(:product_version) { "12" }
+          let(:expected_version) { /^12.\d.\d\+[0-9]{14}$/ }
+
+          it_behaves_like "the right artifact list info"
+        end
+
+        context "with latest version keyword" do
+          let(:product_version) { "latest" }
+          let(:expected_version) { /\d.\d.\d/ }
+
+          it_behaves_like "the right artifact list info"
         end
       end
     end

--- a/spec/mixlib/install/backend_spec.rb
+++ b/spec/mixlib/install/backend_spec.rb
@@ -326,7 +326,7 @@ context "Mixlib::Install::Backend" do
 
         context "with latest version keyword" do
           let(:product_version) { "latest" }
-          let(:expected_version) { /\d.\d.\d/ }
+          let(:expected_version) { /^\d\d.\d.\d\+[0-9]{14}$/ }
 
           it_behaves_like "the right artifact list info"
         end


### PR DESCRIPTION
In this PR we add the ability to acquire information from omnitruck without platfom specific info. We use the brand new `/versions` endpoint. 

@schisamo @patrick-wright @thommay 