### PR TITLE
Add contributing.md that identifies the maintenance strategy and maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+This project is maintained by the contribution guidelines identified for
+  [chef](https://github.com/chef/chef) project. You can find the guidelines here:
+
+https://github.com/chef/chef/blob/master/CONTRIBUTING.md
+
+Pull requests in this project are merged when they have two :+1:s from maintainers.
+
+## Maintainers
+
+
+- [Thom May](https://github.com/thommay)
+- [Patrick Wright](https://github.com/patrick-wright)
+- [Serdar Sutay](https://github.com/sersut)
+- [Seth Chisamore](https://github.com/schisamo)

--- a/spec/mixlib/install/backend_spec.rb
+++ b/spec/mixlib/install/backend_spec.rb
@@ -41,7 +41,7 @@ context "Mixlib::Install::Backend" do
   shared_examples_for "the right artifact info" do
     it "gives the right url artifact info" do
       if !expected_info.key?(:url)
-        expect(info.url).to match "http"
+        expect(info.url).to match "https://"
       else
         expect(info.url).to match expected_info[:url]
       end
@@ -155,7 +155,7 @@ context "Mixlib::Install::Backend" do
           let(:product_version) { "12.2.1" }
           let(:expected_info) {
             {
-              url: "http://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.7/x86_64/chef-12.2.1-1.dmg",
+              url: "https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.7/x86_64/chef-12.2.1-1.dmg",
               md5: "d00335944b2999d0511e6db30d1e71dc",
               sha256: "53034d6e1eea0028666caee43b99f43d2ca9dd24b260bc53ae5fad1075e83923",
               version: "12.2.1"
@@ -169,7 +169,7 @@ context "Mixlib::Install::Backend" do
           let(:product_version) { "12.2" }
           let(:expected_info) {
             {
-              url: "http://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.7/x86_64/chef-12.2",
+              url: "https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.7/x86_64/chef-12.2",
               version: "12.2"
             }
           }
@@ -181,7 +181,7 @@ context "Mixlib::Install::Backend" do
           let(:product_version) { "12" }
           let(:expected_info) {
             {
-              url: "http://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.7/x86_64/chef-12",
+              url: "https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.7/x86_64/chef-12",
               version: "12"
             }
           }
@@ -240,7 +240,7 @@ context "Mixlib::Install::Backend" do
           let(:product_version) { "12.4.3+20151006083011" }
           let(:expected_info) {
             {
-              url: "http://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12.4.3%2B20151006083011-1.dmg",
+              url: "https://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12.4.3%2B20151006083011-1.dmg",
               md5: "103f98e4b72407245bdf44a0357fd8e4",
               sha256: "c74cac0ecdef969820770c6e21fcf249d623dba40ea9bacdb2de5cd3bfbeedaf",
               version: "12.4.3+20151006083011"
@@ -254,7 +254,7 @@ context "Mixlib::Install::Backend" do
           let(:product_version) { "12.4.3" }
           let(:expected_info) {
             {
-              url: "http://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12.4.3%2B",
+              url: "https://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12.4.3%2B",
               version: "12.4.3+"
             }
           }
@@ -266,7 +266,7 @@ context "Mixlib::Install::Backend" do
           let(:product_version) { "12.4" }
           let(:expected_info) {
             {
-              url: "http://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12.4",
+              url: "https://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12.4",
               version: "12.4"
             }
           }
@@ -278,7 +278,7 @@ context "Mixlib::Install::Backend" do
           let(:product_version) { "12" }
           let(:expected_info) {
             {
-              url: "http://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12",
+              url: "https://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12",
               version: "12"
             }
           }


### PR DESCRIPTION
@schisamo @patrick-wright @thommay 

Also testing if the `JSON.parse()` issues are still happening with the recent cache key change to fastly in omnitruck.