### PR TITLE
Required helper methods to support chef-ingredient

### DIFF
--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+require "mixlib/versioning"
+
 require "mixlib/install/backend"
 require "mixlib/install/options"
 require "mixlib/install/generator"
@@ -58,6 +60,33 @@ module Mixlib
       # This only works for chef and chefdk but they are the only projects
       # we are supporting as of now.
       "/opt/#{options.product_name}"
+    end
+
+    #
+    # Returns the current version of the installed product.
+    # Returns nil if the product is not installed.
+    #
+    def current_version
+      # Note that this logic does not work for products other than
+      # chef & chefdk since version-manifest is created under the
+      # install directory which can be different than the product name (e.g.
+      # chef-server -> /opt/opscode). But this is OK for now since
+      # chef & chefdk are the only supported products for now.
+      version_manifest_file = "/opt/#{options.product_name}/version-manifest.json"
+      if File.exist? version_manifest_file
+        JSON.parse(File.read(version_manifest_file))["build_version"]
+      end
+    end
+
+    #
+    # Returns true if an upgradable version is available, false otherwise.
+    #
+    def upgrade_available?
+      return false if current_version.nil?
+
+      available_ver = Mixlib::Versioning.parse(artifact_info.first.version)
+      current_ver = Mixlib::Versioning.parse(current_version)
+      (available_ver > current_ver)
     end
   end
 end

--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -71,7 +71,7 @@ module Mixlib
       # chef & chefdk since version-manifest is created under the
       # install directory which can be different than the product name (e.g.
       # chef-server -> /opt/opscode). But this is OK for now since
-      # chef & chefdk are the only supported products for now.
+      # chef & chefdk are the only supported products.
       version_manifest_file = "/opt/#{options.product_name}/version-manifest.json"
       if File.exist? version_manifest_file
         JSON.parse(File.read(version_manifest_file))["build_version"]
@@ -82,7 +82,7 @@ module Mixlib
     # Returns true if an upgradable version is available, false otherwise.
     #
     def upgrade_available?
-      return false if current_version.nil?
+      return true if current_version.nil?
 
       available_ver = Mixlib::Versioning.parse(artifact_info.first.version)
       current_ver = Mixlib::Versioning.parse(current_version)

--- a/mixlib-install.gemspec
+++ b/mixlib-install.gemspec
@@ -17,9 +17,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # spec.required_ruby_version = ">= 2.0.0"
-
   spec.add_dependency "artifactory", "~> 2.3.0"
+  spec.add_dependency "mixlib-versioning", "~> 1.1.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/mixlib/install_spec.rb
+++ b/spec/mixlib/install_spec.rb
@@ -76,6 +76,17 @@ context "Mixlib::Install" do
       allow(installer).to receive(:current_version).and_return(current_version)
     end
 
+    context "with nil as current_version" do
+      let(:product_name) { "chefdk" }
+      let(:channel) { :stable }
+      let(:product_version) { :latest }
+      let(:current_version) { nil }
+
+      it "should report upgrade available" do
+        expect(installer.upgrade_available?).to eq(true)
+      end
+    end
+
     context "with :latest, upgrade exists, :stable channel" do
       let(:product_name) { "chefdk" }
       let(:channel) { :stable }

--- a/spec/mixlib/install_spec.rb
+++ b/spec/mixlib/install_spec.rb
@@ -1,0 +1,113 @@
+#
+# Copyright:: Copyright (c) 2015 Chef, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "mixlib/install"
+
+context "Mixlib::Install" do
+  let(:installer) do
+    Mixlib::Install.new(
+      product_name: product_name,
+      channel: channel,
+      product_version: product_version
+    )
+  end
+
+  let(:channel) { :stable }
+  let(:product_version) { :latest }
+
+  context "querying current version" do
+    let(:version_manifest_file) { "/opt/#{product_name}/version-manifest.json" }
+
+    context "when products are installed" do
+      before do
+        expect(File).to receive(:exist?).with(version_manifest_file).and_return(true)
+        expect(File).to receive(:read).with(version_manifest_file).and_wrap_original do |m, path|
+          m.call(File.join(VERSION_MANIFEST_DIR, path))
+        end
+      end
+
+      context "with product name chef" do
+        let(:product_name) { "chef" }
+
+        it "should report version correctly" do
+          expect(installer.current_version).to eq("12.4.3")
+        end
+      end
+
+      context "with product name chef" do
+        let(:product_name) { "chefdk" }
+
+        it "should report version correctly" do
+          expect(installer.current_version).to eq("0.7.0")
+        end
+      end
+    end
+
+    context "when product is not installed" do
+      let(:product_name) { "chef" }
+
+      before do
+        expect(File).to receive(:exist?).with(version_manifest_file).and_return(false)
+      end
+
+      it "should report version as nil" do
+        expect(installer.current_version).to eq(nil)
+      end
+    end
+  end
+
+  context "checking for upgrades" do
+    before do
+      allow(installer).to receive(:current_version).and_return(current_version)
+    end
+
+    context "with :latest, upgrade exists, :stable channel" do
+      let(:product_name) { "chefdk" }
+      let(:channel) { :stable }
+      let(:product_version) { :latest }
+      let(:current_version) { "0.4.0" }
+
+      it "should report upgrade available" do
+        expect(installer.upgrade_available?).to eq(true)
+      end
+    end
+
+    context "with specific version lower than current, :stable channel" do
+      let(:product_name) { "chefdk" }
+      let(:channel) { :stable }
+      let(:product_version) { "0.3.0" }
+      let(:current_version) { "0.4.0" }
+
+      it "should report upgrade available" do
+        expect(installer.upgrade_available?).to eq(false)
+      end
+    end
+
+    context "with specific version higher than current, :stable channel" do
+      let(:product_name) { "chefdk" }
+      let(:channel) { :stable }
+      let(:product_version) { "0.7.0" }
+      let(:current_version) { "0.4.0" }
+
+      it "should report upgrade available" do
+        expect(installer.upgrade_available?).to eq(true)
+      end
+    end
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
+VERSION_MANIFEST_DIR = File.expand_path("../support/version_manifests", __FILE__)
+
 RSpec.configure do |conf|
   conf.filter_run focus: true
   conf.filter_run_excluding unstable: true

--- a/spec/support/version_manifests/opt/chef/version-manifest.json
+++ b/spec/support/version_manifests/opt/chef/version-manifest.json
@@ -1,0 +1,208 @@
+{
+  "manifest_format": 1,
+  "software": {
+    "preparation": {
+      "locked_version": "1.0.0",
+      "locked_source": null,
+      "source_type": "project_local",
+      "described_version": "1.0.0"
+    },
+    "zlib": {
+      "locked_version": "1.2.8",
+      "locked_source": {
+        "md5": "44d667c142d7cda120332623eab69f40",
+        "url": "http://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "1.2.8"
+    },
+    "ncurses": {
+      "locked_version": "5.9",
+      "locked_source": {
+        "md5": "8cb9c412e5f2d96bc6f459aa8c6282a1",
+        "url": "http://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "5.9"
+    },
+    "libedit": {
+      "locked_version": "20120601-3.0",
+      "locked_source": {
+        "md5": "e50f6a7afb4de00c81650f7b1a0f5aea",
+        "url": "http://www.thrysoee.dk/editline/libedit-20120601-3.0.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "20120601-3.0"
+    },
+    "cacerts": {
+      "locked_version": "2015.09.02",
+      "locked_source": {
+        "md5": "3e0e6f302bd4f5b94040b8bcee0ffe15",
+        "url": "http://curl.haxx.se/ca/cacert.pem"
+      },
+      "source_type": "url",
+      "described_version": "2015.09.02"
+    },
+    "xproto": {
+      "locked_version": "7.0.25",
+      "locked_source": {
+        "url": "http://xorg.freedesktop.org/releases/individual/proto/xproto-7.0.25.tar.gz",
+        "md5": "a47db46cb117805bd6947aa5928a7436"
+      },
+      "source_type": "url",
+      "described_version": "7.0.25"
+    },
+    "util-macros": {
+      "locked_version": "1.18.0",
+      "locked_source": {
+        "url": "http://xorg.freedesktop.org/releases/individual/util/util-macros-1.18.0.tar.gz",
+        "md5": "fd0ba21b3179703c071bbb4c3e5fb0f4"
+      },
+      "source_type": "url",
+      "described_version": "1.18.0"
+    },
+    "libiconv": {
+      "locked_version": "1.14",
+      "locked_source": {
+        "url": "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz",
+        "md5": "e34509b1623cec449dfeb73d7ce9c6c6"
+      },
+      "source_type": "url",
+      "described_version": "1.14"
+    },
+    "pkg-config": {
+      "locked_version": "0.28",
+      "locked_source": {
+        "md5": "aa3c86e67551adc3ac865160e34a2a0d",
+        "url": "http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "0.28"
+    },
+    "makedepend": {
+      "locked_version": "1.0.5",
+      "locked_source": {
+        "url": "http://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz",
+        "md5": "efb2d7c7e22840947863efaedc175747"
+      },
+      "source_type": "url",
+      "described_version": "1.0.5"
+    },
+    "openssl": {
+      "locked_version": "1.0.1p",
+      "locked_source": {
+        "url": "https://www.openssl.org/source/openssl-1.0.1p.tar.gz",
+        "md5": "7563e92327199e0067ccd0f79f436976"
+      },
+      "source_type": "url",
+      "described_version": "1.0.1p"
+    },
+    "libyaml": {
+      "locked_version": "0.1.6",
+      "locked_source": {
+        "url": "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz",
+        "md5": "5fe00cda18ca5daeb43762b80c38e06e"
+      },
+      "source_type": "url",
+      "described_version": "0.1.6"
+    },
+    "libtool": {
+      "locked_version": "2.4",
+      "locked_source": {
+        "md5": "b32b04148ecdd7344abc6fe8bd1bb021",
+        "url": "http://ftp.gnu.org/gnu/libtool/libtool-2.4.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "2.4"
+    },
+    "libffi": {
+      "locked_version": "3.2.1",
+      "locked_source": {
+        "md5": "83b89587607e3eb65c70d361f13bab43",
+        "url": "ftp://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "3.2.1"
+    },
+    "gdbm": {
+      "locked_version": "1.9.1",
+      "locked_source": {
+        "md5": "59f6e4c4193cb875964ffbe8aa384b58",
+        "url": "http://ftp.gnu.org/gnu/gdbm/gdbm-1.9.1.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "1.9.1"
+    },
+    "ruby": {
+      "locked_version": "2.1.6",
+      "locked_source": {
+        "md5": "6e5564364be085c45576787b48eeb75f",
+        "url": "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "2.1.6"
+    },
+    "rubygems": {
+      "locked_version": "2.4.8",
+      "locked_source": {
+        "git": "https://github.com/rubygems/rubygems.git",
+        "md5": "dc77b51449dffe5b31776bff826bf559",
+        "url": "http://production.cf.rubygems.org/rubygems/rubygems-2.4.8.tgz"
+      },
+      "source_type": "url",
+      "described_version": "2.4.8"
+    },
+    "bundler": {
+      "locked_version": "403902bed6f0638f4147e8bde0a6650116ea2327",
+      "locked_source": {
+        "git": "https://github.com/chef/bundler.git"
+      },
+      "source_type": "git",
+      "described_version": "1.10.7.depsolverfix.0"
+    },
+    "ohai": {
+      "locked_version": "51a4fd97d0f03a75ae219190b29128c79b6e6a58",
+      "locked_source": {
+        "git": "git://github.com/opscode/ohai"
+      },
+      "source_type": "git",
+      "described_version": "8.5.1"
+    },
+    "appbundler": {
+      "locked_version": "0.5.0",
+      "locked_source": null,
+      "source_type": "project_local",
+      "described_version": "0.5.0"
+    },
+    "chef": {
+      "locked_version": "b306b12b7167f03257e179f714b9eecd0319828f",
+      "locked_source": {
+        "git": "git://github.com/chef/chef"
+      },
+      "source_type": "git",
+      "described_version": "stable"
+    },
+    "shebang-cleanup": {
+      "locked_version": "0.0.2",
+      "locked_source": null,
+      "source_type": "project_local",
+      "described_version": "0.0.2"
+    },
+    "version-manifest": {
+      "locked_version": "0.0.1",
+      "locked_source": null,
+      "source_type": "project_local",
+      "described_version": "0.0.1"
+    },
+    "openssl-customization": {
+      "locked_version": null,
+      "locked_source": {
+        "path": "/home/jenkins/workspace/chef-12-build/architecture/x86_64/platform/ubuntu-10.04/project/chef/role/builder/files/openssl-customization"
+      },
+      "source_type": "path",
+      "described_version": null
+    }
+  },
+  "build_version": "12.4.3",
+  "build_git_revision": "0f5884da97d87d4c1c73e70dbd7cf01e9e25b532"
+}

--- a/spec/support/version_manifests/opt/chefdk/version-manifest.json
+++ b/spec/support/version_manifests/opt/chefdk/version-manifest.json
@@ -1,0 +1,342 @@
+{
+  "manifest_format": 1,
+  "software": {
+    "preparation": {
+      "locked_version": "1.0.0",
+      "locked_source": null,
+      "source_type": "project_local",
+      "described_version": "1.0.0"
+    },
+    "libtool": {
+      "locked_version": "2.4.2",
+      "locked_source": {
+        "md5": "d2f3b7d4627e69e13514a40e72a24d50",
+        "url": "http://ftp.gnu.org/gnu/libtool/libtool-2.4.2.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "2.4.2"
+    },
+    "libffi": {
+      "locked_version": "3.2.1",
+      "locked_source": {
+        "md5": "83b89587607e3eb65c70d361f13bab43",
+        "url": "ftp://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "3.2.1"
+    },
+    "zlib": {
+      "locked_version": "1.2.8",
+      "locked_source": {
+        "md5": "44d667c142d7cda120332623eab69f40",
+        "url": "http://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "1.2.8"
+    },
+    "ncurses": {
+      "locked_version": "5.9-20150530",
+      "locked_source": {
+        "md5": "bb2cbe1d788d3ab0138fc2734e446b43",
+        "url": "ftp://invisible-island.net/ncurses/current/ncurses-5.9-20150530.tgz"
+      },
+      "source_type": "url",
+      "described_version": "5.9-20150530"
+    },
+    "libedit": {
+      "locked_version": "20130712-3.1",
+      "locked_source": {
+        "md5": "0891336c697362727a1fa7e60c5cb96c",
+        "url": "http://www.thrysoee.dk/editline/libedit-20130712-3.1.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "20130712-3.1"
+    },
+    "cacerts": {
+      "locked_version": "2015.04.22",
+      "locked_source": {
+        "md5": "380df856e8f789c1af97d0da9a243769",
+        "url": "http://curl.haxx.se/ca/cacert.pem"
+      },
+      "source_type": "url",
+      "described_version": "2015.04.22"
+    },
+    "xproto": {
+      "locked_version": "7.0.25",
+      "locked_source": {
+        "url": "http://xorg.freedesktop.org/releases/individual/proto/xproto-7.0.25.tar.gz",
+        "md5": "a47db46cb117805bd6947aa5928a7436"
+      },
+      "source_type": "url",
+      "described_version": "7.0.25"
+    },
+    "util-macros": {
+      "locked_version": "1.18.0",
+      "locked_source": {
+        "url": "http://xorg.freedesktop.org/releases/individual/util/util-macros-1.18.0.tar.gz",
+        "md5": "fd0ba21b3179703c071bbb4c3e5fb0f4"
+      },
+      "source_type": "url",
+      "described_version": "1.18.0"
+    },
+    "libiconv": {
+      "locked_version": "1.14",
+      "locked_source": {
+        "url": "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz",
+        "md5": "e34509b1623cec449dfeb73d7ce9c6c6"
+      },
+      "source_type": "url",
+      "described_version": "1.14"
+    },
+    "pkg-config": {
+      "locked_version": "0.28",
+      "locked_source": {
+        "md5": "aa3c86e67551adc3ac865160e34a2a0d",
+        "url": "http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "0.28"
+    },
+    "makedepend": {
+      "locked_version": "1.0.5",
+      "locked_source": {
+        "url": "http://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz",
+        "md5": "efb2d7c7e22840947863efaedc175747"
+      },
+      "source_type": "url",
+      "described_version": "1.0.5"
+    },
+    "openssl": {
+      "locked_version": "1.0.1p",
+      "locked_source": {
+        "url": "https://www.openssl.org/source/openssl-1.0.1p.tar.gz",
+        "md5": "7563e92327199e0067ccd0f79f436976"
+      },
+      "source_type": "url",
+      "described_version": "1.0.1p"
+    },
+    "libyaml": {
+      "locked_version": "0.1.6",
+      "locked_source": {
+        "url": "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz",
+        "md5": "5fe00cda18ca5daeb43762b80c38e06e"
+      },
+      "source_type": "url",
+      "described_version": "0.1.6"
+    },
+    "gdbm": {
+      "locked_version": "1.9.1",
+      "locked_source": {
+        "md5": "59f6e4c4193cb875964ffbe8aa384b58",
+        "url": "http://ftp.gnu.org/gnu/gdbm/gdbm-1.9.1.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "1.9.1"
+    },
+    "ruby": {
+      "locked_version": "2.1.6",
+      "locked_source": {
+        "md5": "6e5564364be085c45576787b48eeb75f",
+        "url": "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "2.1.6"
+    },
+    "rubygems": {
+      "locked_version": "2.4.4",
+      "locked_source": {
+        "git": "https://github.com/rubygems/rubygems.git",
+        "md5": "440a89ad6a3b1b7a69b034233cc4658e",
+        "url": "http://production.cf.rubygems.org/rubygems/rubygems-2.4.4.tgz"
+      },
+      "source_type": "url",
+      "described_version": "2.4.4"
+    },
+    "bundler": {
+      "locked_version": "1.10.0",
+      "locked_source": null,
+      "source_type": "project_local",
+      "described_version": "1.10.0"
+    },
+    "appbundler": {
+      "locked_version": "0.4.0",
+      "locked_source": null,
+      "source_type": "project_local",
+      "described_version": "0.4.0"
+    },
+    "libarchive": {
+      "locked_version": "3.1.2",
+      "locked_source": {
+        "url": "http://www.libarchive.org/downloads/libarchive-3.1.2.tar.gz",
+        "md5": "efad5a503f66329bb9d2f4308b5de98a"
+      },
+      "source_type": "url",
+      "described_version": "3.1.2"
+    },
+    "liblzma": {
+      "locked_version": "5.0.5",
+      "locked_source": {
+        "url": "http://tukaani.org/xz/xz-5.0.5.tar.gz",
+        "md5": "19d924e066b6fff0bc9d1981b4e53196"
+      },
+      "source_type": "url",
+      "described_version": "5.0.5"
+    },
+    "libxml2": {
+      "locked_version": "2.9.1",
+      "locked_source": {
+        "md5": "9c0cfef285d5c4a5c80d00904ddab380",
+        "url": "ftp://xmlsoft.org/libxml2/libxml2-2.9.1.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "2.9.1"
+    },
+    "libxslt": {
+      "locked_version": "1.1.28",
+      "locked_source": {
+        "md5": "9667bf6f9310b957254fdcf6596600b7",
+        "url": "ftp://xmlsoft.org/libxml2/libxslt-1.1.28.tar.gz"
+      },
+      "source_type": "url",
+      "described_version": "1.1.28"
+    },
+    "nokogiri": {
+      "locked_version": "1.6.3.1",
+      "locked_source": null,
+      "source_type": "project_local",
+      "described_version": "1.6.3.1"
+    },
+    "dep-selector-libgecode": {
+      "locked_version": "1.0.2",
+      "locked_source": null,
+      "source_type": "project_local",
+      "described_version": "1.0.2"
+    },
+    "berkshelf": {
+      "locked_version": "6289ea0bb0e378a9309f2af96eac33022c6af68e",
+      "locked_source": {
+        "git": "git://github.com/danielsdeleo/berkshelf"
+      },
+      "source_type": "git",
+      "described_version": "3.2.4-plus-lock-celluloid"
+    },
+    "ohai": {
+      "locked_version": "51a4fd97d0f03a75ae219190b29128c79b6e6a58",
+      "locked_source": {
+        "git": "git://github.com/opscode/ohai"
+      },
+      "source_type": "git",
+      "described_version": "8.5.1"
+    },
+    "chef": {
+      "locked_version": "1dc20627aa5d742376269dc5b4d5c67f34d08008",
+      "locked_source": {
+        "git": "git://github.com/chef/chef"
+      },
+      "source_type": "git",
+      "described_version": "12.4.1"
+    },
+    "chef-vault": {
+      "locked_version": "343ab1ef9439e94694c357ee431a30258b37ed1a",
+      "locked_source": {
+        "git": "git://github.com/Nordstrom/chef-vault.git"
+      },
+      "source_type": "git",
+      "described_version": "v2.6.1"
+    },
+    "foodcritic": {
+      "locked_version": "f2952ff49c487263534eac6d04a1801bde072ae0",
+      "locked_source": {
+        "git": "git://github.com/acrmp/foodcritic.git"
+      },
+      "source_type": "git",
+      "described_version": "v4.0.0"
+    },
+    "test-kitchen": {
+      "locked_version": "ac0d6cb454671e7b523258dbd2816cb364259966",
+      "locked_source": {
+        "git": "git://github.com/test-kitchen/test-kitchen"
+      },
+      "source_type": "git",
+      "described_version": "v1.4.2"
+    },
+    "kitchen-vagrant": {
+      "locked_version": "7b033a648972c2e5b773dfe8cf89cb169d5e158f",
+      "locked_source": {
+        "git": "git://github.com/test-kitchen/kitchen-vagrant.git"
+      },
+      "source_type": "git",
+      "described_version": "v0.18.0"
+    },
+    "openssl-customization": {
+      "locked_version": null,
+      "locked_source": {
+        "path": "/home/jenkins/workspace/chefdk-build/architecture/x86_64/platform/ubuntu-12.04/project/chefdk/role/builder/files/openssl-customization"
+      },
+      "source_type": "path",
+      "described_version": null
+    },
+    "chefdk": {
+      "locked_version": "512f391e024e4a3018ae52c9f66c1021d26bf16c",
+      "locked_source": {
+        "git": "git://github.com/chef/chef-dk.git"
+      },
+      "source_type": "git",
+      "described_version": "0.7.0"
+    },
+    "chef-provisioning-fog": {
+      "locked_version": "7ea17f167c1ef28cc417f1665594835a3aade554",
+      "locked_source": {
+        "git": "git://github.com/chef/chef-provisioning-fog.git"
+      },
+      "source_type": "git",
+      "described_version": "v0.13.2"
+    },
+    "chef-provisioning-vagrant": {
+      "locked_version": "2a8f2865d066be02a867a77a29797f02e71c05c9",
+      "locked_source": {
+        "git": "git://github.com/chef/chef-provisioning-vagrant.git"
+      },
+      "source_type": "git",
+      "described_version": "v0.9.0"
+    },
+    "chef-provisioning-azure": {
+      "locked_version": "f8182c2cdd9080d6a78c72d98faad4678a54bb6c",
+      "locked_source": {
+        "git": "git://github.com/chef/chef-provisioning-azure.git"
+      },
+      "source_type": "git",
+      "described_version": "v0.3.2"
+    },
+    "chef-provisioning-aws": {
+      "locked_version": "3cadab9584a6e13175452da6e4b0e2e6ccc1adfd",
+      "locked_source": {
+        "git": "git://github.com/chef/chef-provisioning-aws.git"
+      },
+      "source_type": "git",
+      "described_version": "v1.3.1"
+    },
+    "rubygems-customization": {
+      "locked_version": null,
+      "locked_source": {
+        "path": "/home/jenkins/workspace/chefdk-build/architecture/x86_64/platform/ubuntu-12.04/project/chefdk/role/builder/files/rubygems-customization"
+      },
+      "source_type": "path",
+      "described_version": null
+    },
+    "shebang-cleanup": {
+      "locked_version": "0.0.2",
+      "locked_source": null,
+      "source_type": "project_local",
+      "described_version": "0.0.2"
+    },
+    "version-manifest": {
+      "locked_version": "0.0.1",
+      "locked_source": null,
+      "source_type": "project_local",
+      "described_version": "0.0.1"
+    }
+  },
+  "build_version": "0.7.0",
+  "build_git_revision": "8ea89f64f613573fbe0cc4503342cdab7a9d45cd"
+}


### PR DESCRIPTION
This PR adds the required helper methods to use mixlib-install in chef-ingredient.

/cc: @schisamo, @patrick-wright, @thommay, @jtimberman 

Note that there are more things to move from mixlib-install to here but they will be moved in a different PR.