### PR TITLE
Move product matrix and its documentation from chef-ingredient.

### DIFF
--- a/PRODUCT_MATRIX.md
+++ b/PRODUCT_MATRIX.md
@@ -1,20 +1,20 @@
-| Product | Product Key  | Package Name |
-| ------- | ------------ | ------------ |
-| Chef Client | chef | chef |
-| Chef Development Kit | chefdk | chefdk |
-| Chef Server | chef-server | chef-server-core |
-| Management Console | manage | chef-manage |
-| Chef Server High Availability addon | chef-ha | chef-ha |
-| Chef Server Reporting addon | reporting | opscode-reporting |
-| Chef Cloud Marketplace addon | supermarket | supermarket |
-| Chef Cloud Marketplace addon | chef-marketplace | chef-marketplace |
-| Chef Server Replication addon | chef-sync | chef-sync |
-| Delivery | delivery | delivery |
-| Delivery CLI | delivery-cli | delivery-cli |
-| Analytics Platform | analytics | opscode-analytics |
-| Chef Compliance | compliance | chef-compliance |
-| Chef Push Server | push-server | push-jobs-server |
-| Chef Push Server | push-client | push-jobs-client |
-| Enterprise Chef (legacy) | private-chef | private-chef |
+| Product | Product Key  |
+| ------- | ------------ |
+| Analytics Platform | analytics |
+| Chef Client | chef |
+| Chef Server High Availability addon | chef-ha |
+| Chef Cloud Marketplace addon | chef-marketplace |
+| Chef Server | chef-server |
+| Chef Server Replication addon | chef-sync |
+| Chef Development Kit | chefdk |
+| Chef Compliance | compliance |
+| Delivery | delivery |
+| Delivery CLI | delivery-cli |
+| Management Console | manage |
+| Enterprise Chef (legacy) | private-chef |
+| Chef Push Server | push-client |
+| Chef Push Server | push-server |
+| Chef Server Reporting addon | reporting |
+| Supermarket | supermarket |
 
 Do not modify this file manually. It is automatically rendered via a rake task.

--- a/PRODUCT_MATRIX.md
+++ b/PRODUCT_MATRIX.md
@@ -1,0 +1,20 @@
+| Product | Product Key  | Package Name |
+| ------- | ------------ | ------------ |
+| Chef Client | chef | chef |
+| Chef Development Kit | chefdk | chefdk |
+| Chef Server | chef-server | chef-server-core |
+| Management Console | manage | chef-manage |
+| Chef Server High Availability addon | chef-ha | chef-ha |
+| Chef Server Reporting addon | reporting | opscode-reporting |
+| Chef Cloud Marketplace addon | supermarket | supermarket |
+| Chef Cloud Marketplace addon | chef-marketplace | chef-marketplace |
+| Chef Server Replication addon | chef-sync | chef-sync |
+| Delivery | delivery | delivery |
+| Delivery CLI | delivery-cli | delivery-cli |
+| Analytics Platform | analytics | opscode-analytics |
+| Chef Compliance | compliance | chef-compliance |
+| Chef Push Server | push-server | push-jobs-server |
+| Chef Push Server | push-client | push-jobs-client |
+| Enterprise Chef (legacy) | private-chef | private-chef |
+
+Do not modify this file manually. It is automatically rendered via a rake task.

--- a/Rakefile
+++ b/Rakefile
@@ -17,3 +17,22 @@ end
 
 desc "Run all tests"
 task test: [:rubocop, :spec]
+
+desc "Render product matrix documentation"
+task "matrix" do
+  require "mixlib/install/product"
+
+  doc_file = File.join(File.dirname(__FILE__), "PRODUCT_MATRIX.md")
+  puts "Updating doc file at: #{doc_file}"
+
+  File.open(doc_file, "w+") do |f|
+    f.puts("| Product | Product Key  | Package Name |")
+    f.puts("| ------- | ------------ | ------------ |")
+    PRODUCT_MATRIX.products.each do |p_key|
+      product = PRODUCT_MATRIX.lookup(p_key)
+      f.puts("| #{product.product_name} | #{p_key} | #{product.package_name} |")
+    end
+    f.puts("")
+    f.puts("Do not modify this file manually. It is automatically rendered via a rake task.")
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -26,11 +26,11 @@ task "matrix" do
   puts "Updating doc file at: #{doc_file}"
 
   File.open(doc_file, "w+") do |f|
-    f.puts("| Product | Product Key  | Package Name |")
-    f.puts("| ------- | ------------ | ------------ |")
-    PRODUCT_MATRIX.products.each do |p_key|
+    f.puts("| Product | Product Key  |")
+    f.puts("| ------- | ------------ |")
+    PRODUCT_MATRIX.products.sort.each do |p_key|
       product = PRODUCT_MATRIX.lookup(p_key)
-      f.puts("| #{product.product_name} | #{p_key} | #{product.package_name} |")
+      f.puts("| #{product.product_name} | #{p_key} |")
     end
     f.puts("")
     f.puts("Do not modify this file manually. It is automatically rendered via a rake task.")

--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -24,7 +24,12 @@ module Mixlib
         instance_eval(&block)
       end
 
-      DSL_PROPERTIES = [:product_name, :package_name, :ctl_command, :config_file]
+      DSL_PROPERTIES = [
+        :config_file,
+        :ctl_command,
+        :package_name,
+        :product_name
+      ]
 
       #
       # DSL methods can receive either a String or a Proc to calculate the
@@ -49,13 +54,13 @@ module Mixlib
               if value.is_a? String
                 value
               else
-                value.call(version)
+                value.call(version_for(version))
               end
             else
               instance_variable_set("@#{prop}".to_sym, prop_string)
             end
           else
-            raise "Not both at the same time." if !prop_string.nil?
+            raise "Can not use String and Proc at the same time for #{prop}." if !prop_string.nil?
             instance_variable_set("@#{prop}".to_sym, block)
           end
         end
@@ -136,14 +141,31 @@ end
 # to update PRODUCT_MATRIX.md.
 #
 PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
+  # Products in alphabetical order
+
+  product "analytics" do
+    product_name "Analytics Platform"
+    package_name "opscode-analytics"
+    ctl_command "opscode-analytics-ctl"
+    config_file "/etc/opscode-analytics/opscode-analytics.rb"
+  end
+
   product "chef" do
     product_name "Chef Client"
     package_name "chef"
   end
 
-  product "chefdk" do
-    product_name "Chef Development Kit"
-    package_name "chefdk"
+  product "chef-ha" do
+    product_name "Chef Server High Availability addon"
+    package_name "chef-ha"
+    config_file "/etc/opscode/chef-server.rb"
+  end
+
+  product "chef-marketplace" do
+    product_name "Chef Cloud Marketplace addon"
+    package_name "chef-marketplace"
+    ctl_command "chef-marketplace-ctl"
+    config_file "/etc/chef-marketplace/marketplace.rb"
   end
 
   product "chef-server" do
@@ -159,49 +181,23 @@ PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
     config_file "/etc/opscode/chef-server.rb"
   end
 
-  product "manage" do
-    product_name "Management Console"
-    package_name do |v|
-      v < version_for("2.0.0") ? "opscode-manage" : "chef-manage"
-    end
-    ctl_command do |v|
-      v < version_for("2.0.0") ? "opscode-manage-ctl" : "chef-manage-ctl"
-    end
-    config_file "/etc/opscode-manage/manage.rb"
-  end
-
-  product "chef-ha" do
-    product_name "Chef Server High Availability addon"
-    package_name "chef-ha"
-    config_file "/etc/opscode/chef-server.rb"
-  end
-
-  product "reporting" do
-    product_name "Chef Server Reporting addon"
-    package_name "opscode-reporting"
-    ctl_command "opscode-reporting-ctl"
-    config_file "/etc/opscode-reporting/opscode-reporting.rb"
-  end
-
-  product "supermarket" do
-    product_name "Chef Cloud Marketplace addon"
-    package_name "supermarket"
-    ctl_command "supermarket-ctl"
-    config_file "/etc/supermarket/supermarket.json"
-  end
-
-  product "chef-marketplace" do
-    product_name "Chef Cloud Marketplace addon"
-    package_name "chef-marketplace"
-    ctl_command "chef-marketplace-ctl"
-    config_file "/etc/chef-marketplace/marketplace.rb"
-  end
-
   product "chef-sync" do
     product_name "Chef Server Replication addon"
     package_name "chef-sync"
     ctl_command "chef-sync-ctl"
     config_file "/etc/chef-sync/chef-sync.rb"
+  end
+
+  product "chefdk" do
+    product_name "Chef Development Kit"
+    package_name "chefdk"
+  end
+
+  product "compliance" do
+    product_name "Chef Compliance"
+    package_name "chef-compliance"
+    ctl_command "chef-compliance-ctl"
+    config_file "/etc/chef-compliance/chef-compliance.rb"
   end
 
   product "delivery" do
@@ -216,18 +212,29 @@ PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
     package_name "delivery-cli"
   end
 
-  product "analytics" do
-    product_name "Analytics Platform"
-    package_name "opscode-analytics"
-    ctl_command "opscode-analytics-ctl"
-    config_file "/etc/opscode-analytics/opscode-analytics.rb"
+  product "manage" do
+    product_name "Management Console"
+    package_name do |v|
+      v < version_for("2.0.0") ? "opscode-manage" : "chef-manage"
+    end
+    ctl_command do |v|
+      v < version_for("2.0.0") ? "opscode-manage-ctl" : "chef-manage-ctl"
+    end
+    config_file "/etc/opscode-manage/manage.rb"
   end
 
-  product "compliance" do
-    product_name "Chef Compliance"
-    package_name "chef-compliance"
-    ctl_command "chef-compliance-ctl"
-    config_file "/etc/chef-compliance/chef-compliance.rb"
+  product "private-chef" do
+    product_name "Enterprise Chef (legacy)"
+    package_name "private-chef"
+    ctl_command "private-chef-ctl"
+    config_file "/etc/opscode/private-chef.rb"
+  end
+
+  product "push-client" do
+    product_name "Chef Push Server"
+    package_name do |v|
+      v < version_for("1.3.0") ? "opscode-push-jobs-client" : "push-jobs-client"
+    end
   end
 
   product "push-server" do
@@ -241,19 +248,17 @@ PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
     config_file "/etc/opscode-push-jobs-server/opscode-push-jobs-server.rb"
   end
 
-  product "push-client" do
-    product_name "Chef Push Server"
-    package_name do |v|
-      v < version_for("1.3.0") ? "opscode-push-jobs-client" : "push-jobs-client"
-    end
+  product "reporting" do
+    product_name "Chef Server Reporting addon"
+    package_name "opscode-reporting"
+    ctl_command "opscode-reporting-ctl"
+    config_file "/etc/opscode-reporting/opscode-reporting.rb"
   end
 
-  # LEGACY
-
-  product "private-chef" do
-    product_name "Enterprise Chef (legacy)"
-    package_name "private-chef"
-    ctl_command "private-chef-ctl"
-    config_file "/etc/opscode/private-chef.rb"
+  product "supermarket" do
+    product_name "Supermarket"
+    package_name "supermarket"
+    ctl_command "supermarket-ctl"
+    config_file "/etc/supermarket/supermarket.json"
   end
 end

--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -1,0 +1,259 @@
+#
+# Copyright:: Copyright (c) 2015 Chef, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "mixlib/versioning"
+
+module Mixlib
+  class Install
+    class Product
+      def initialize(&block)
+        instance_eval(&block)
+      end
+
+      DSL_PROPERTIES = [:product_name, :package_name, :ctl_command, :config_file]
+
+      #
+      # DSL methods can receive either a String or a Proc to calculate the
+      # value of the property later on based on the version.
+      # We error out if we get both the String and Proc, and we return the value
+      # of the property if we do not receive anything.
+      #
+      # @param [String] prop_string
+      #   value to be set in String form
+      # @param [Proc] block
+      #   value to be set in Proc form
+      #
+      # @return [String] value of the property
+      #
+      DSL_PROPERTIES.each do |prop|
+        define_method prop do |prop_string = nil, &block|
+          if block.nil?
+            if prop_string.nil?
+              value = instance_variable_get("@#{prop}".to_sym)
+              return nil if value.nil?
+
+              if value.is_a? String
+                value
+              else
+                value.call(version)
+              end
+            else
+              instance_variable_set("@#{prop}".to_sym, prop_string)
+            end
+          else
+            raise "Not both at the same time." if !prop_string.nil?
+            instance_variable_set("@#{prop}".to_sym, block)
+          end
+        end
+      end
+
+      #
+      # Sets or retrieves the version for the product. This is used later
+      # when we are reading the value of a property if a Proc is specified
+      #
+      def version(value = nil)
+        if value.nil?
+          @version
+        else
+          @version = value
+        end
+      end
+
+      #
+      # Helper method to convert versions from String to Mixlib::Version
+      #
+      # @param [String] version_string
+      #   value to be set in String form
+      #
+      # @return [Mixlib::Version]
+      def version_for(version_string)
+        Mixlib::Versioning.parse(version_string)
+      end
+    end
+
+    class ProductMatrix
+      def initialize(&block)
+        @product_map = {}
+        instance_eval(&block)
+      end
+
+      #
+      # The only DSL method of this class. It creates a Product with given
+      # `key` and stores it.
+      #
+      def product(key, &block)
+        @product_map[key] = Product.new(&block)
+      end
+
+      #
+      # Fetches the keys of available products.
+      #
+      # @return Array[String] of keys
+      def products
+        @product_map.keys
+      end
+
+      #
+      # Looks up a product and sets version on it to be used later by the
+      # Product.
+      #
+      # @param [String] key
+      #   Lookup key of the product.
+      # @param [String] version
+      #   Version to be set for the product. By default version is set to :latest
+      #
+      # @return [Product]
+      def lookup(key, version = :latest)
+        product = @product_map[key]
+        # We set the lookup version for the product to a very high number in
+        # order to mimic :latest so that one does not need to handle this
+        # symbol explicitly when constructing logic based on version numbers.
+        version = "1000.1000.1000" if version.to_sym == :latest
+        product.version(version)
+        product
+      end
+    end
+  end
+end
+
+#
+# If you are making a change to PRODUCT_MATRIX, please make sure
+# you run `bundle exec rake matrix` at the home of this repository
+# to update PRODUCT_MATRIX.md.
+#
+PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
+  product "chef" do
+    product_name "Chef Client"
+    package_name "chef"
+  end
+
+  product "chefdk" do
+    product_name "Chef Development Kit"
+    package_name "chefdk"
+  end
+
+  product "chef-server" do
+    product_name "Chef Server"
+    package_name do |v|
+      if (v < version_for("12.0.0")) && (v > version_for("11.0.0"))
+        "chef-server"
+      else
+        "chef-server-core"
+      end
+    end
+    ctl_command "chef-server-ctl"
+    config_file "/etc/opscode/chef-server.rb"
+  end
+
+  product "manage" do
+    product_name "Management Console"
+    package_name do |v|
+      v < version_for("2.0.0") ? "opscode-manage" : "chef-manage"
+    end
+    ctl_command do |v|
+      v < version_for("2.0.0") ? "opscode-manage-ctl" : "chef-manage-ctl"
+    end
+    config_file "/etc/opscode-manage/manage.rb"
+  end
+
+  product "chef-ha" do
+    product_name "Chef Server High Availability addon"
+    package_name "chef-ha"
+    config_file "/etc/opscode/chef-server.rb"
+  end
+
+  product "reporting" do
+    product_name "Chef Server Reporting addon"
+    package_name "opscode-reporting"
+    ctl_command "opscode-reporting-ctl"
+    config_file "/etc/opscode-reporting/opscode-reporting.rb"
+  end
+
+  product "supermarket" do
+    product_name "Chef Cloud Marketplace addon"
+    package_name "supermarket"
+    ctl_command "supermarket-ctl"
+    config_file "/etc/supermarket/supermarket.json"
+  end
+
+  product "chef-marketplace" do
+    product_name "Chef Cloud Marketplace addon"
+    package_name "chef-marketplace"
+    ctl_command "chef-marketplace-ctl"
+    config_file "/etc/chef-marketplace/marketplace.rb"
+  end
+
+  product "chef-sync" do
+    product_name "Chef Server Replication addon"
+    package_name "chef-sync"
+    ctl_command "chef-sync-ctl"
+    config_file "/etc/chef-sync/chef-sync.rb"
+  end
+
+  product "delivery" do
+    product_name "Delivery"
+    package_name "delivery"
+    ctl_command "delivery-ctl"
+    config_file "/etc/delivery/delivery.rb"
+  end
+
+  product "delivery-cli" do
+    product_name "Delivery CLI"
+    package_name "delivery-cli"
+  end
+
+  product "analytics" do
+    product_name "Analytics Platform"
+    package_name "opscode-analytics"
+    ctl_command "opscode-analytics-ctl"
+    config_file "/etc/opscode-analytics/opscode-analytics.rb"
+  end
+
+  product "compliance" do
+    product_name "Chef Compliance"
+    package_name "chef-compliance"
+    ctl_command "chef-compliance-ctl"
+    config_file "/etc/chef-compliance/chef-compliance.rb"
+  end
+
+  product "push-server" do
+    product_name "Chef Push Server"
+    package_name do |v|
+      v < version_for("2.0.0") ? "opscode-push-jobs-server" : "push-jobs-server"
+    end
+    ctl_command do |v|
+      v < version_for("2.0.0") ? "opscode-push-jobs-server-ctl" : "push-jobs-server-ctl"
+    end
+    config_file "/etc/opscode-push-jobs-server/opscode-push-jobs-server.rb"
+  end
+
+  product "push-client" do
+    product_name "Chef Push Server"
+    package_name do |v|
+      v < version_for("1.3.0") ? "opscode-push-jobs-client" : "push-jobs-client"
+    end
+  end
+
+  # LEGACY
+
+  product "private-chef" do
+    product_name "Enterprise Chef (legacy)"
+    package_name "private-chef"
+    ctl_command "private-chef-ctl"
+    config_file "/etc/opscode/private-chef.rb"
+  end
+end

--- a/spec/mixlib/install/product_spec.rb
+++ b/spec/mixlib/install/product_spec.rb
@@ -1,0 +1,254 @@
+#
+# Copyright:: Copyright (c) 2015 Chef, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "mixlib/install/product"
+
+context "Mixlib::Install::Product" do
+  context "for product_name when using strings" do
+    let(:product) {
+      Mixlib::Install::Product.new do
+        product_name "test-product"
+      end
+    }
+
+    it "accepts and returns the value correctly" do
+      expect(product.product_name).to eq("test-product")
+    end
+
+    it "returns nil for unset properties" do
+      expect(product.package_name).to eq(nil)
+    end
+
+    it "errors for unexisting properties" do
+      expect { product.address }.to raise_error(StandardError)
+    end
+  end
+
+  context "for package_name when using block" do
+    let(:product) {
+      Mixlib::Install::Product.new do
+        package_name do |version|
+          "my-version-#{version}"
+        end
+      end
+    }
+
+    it "accepts and returns the value correctly without a version" do
+      expect(product.package_name).to eq("my-version-")
+    end
+
+    it "accepts and returns the value correctly with a version" do
+      product.version("110")
+      expect(product.package_name).to eq("my-version-110")
+    end
+
+    it "returns nil for unset properties" do
+      expect(product.product_name).to eq(nil)
+    end
+
+    it "errors for unexisting properties" do
+      expect { product.address }.to raise_error(StandardError)
+    end
+  end
+
+  context "for package_name when using block and string" do
+    let(:product) {
+      Mixlib::Install::Product.new do
+        package_name "my-name" do |version|
+          "my-version-#{version}"
+        end
+      end
+    }
+
+    it "should error" do
+      expect { product }.to raise_error(StandardError)
+    end
+  end
+
+  it "has version_for defined" do
+    expect(Mixlib::Install::Product.new {}).to respond_to(:version_for)
+  end
+
+  it "has the DSL methods for all required properties" do
+    expect(Mixlib::Install::Product::DSL_PROPERTIES).to include(:product_name)
+    expect(Mixlib::Install::Product::DSL_PROPERTIES).to include(:package_name)
+    expect(Mixlib::Install::Product::DSL_PROPERTIES).to include(:ctl_command)
+    expect(Mixlib::Install::Product::DSL_PROPERTIES).to include(:config_file)
+  end
+end
+
+context "PRODUCT_MATRIX" do
+  let(:package_name) do
+    PRODUCT_MATRIX.lookup(product_name, version).package_name
+  end
+
+  let(:ctl_command) do
+    PRODUCT_MATRIX.lookup(product_name, version).ctl_command
+  end
+
+  CHEF_PRODUCTS = ["chef", "chefdk", "chef-server", "manage", "chef-ha",
+                   "reporting", "supermarket", "chef-marketplace", "chef-sync",
+                   "delivery", "delivery-cli", "analytics", "compliance",
+                   "push-server", "push-client", "private-chef"]
+
+  it "has entries for all #{CHEF_PRODUCTS.length} products" do
+    CHEF_PRODUCTS.each do |p|
+      expect(PRODUCT_MATRIX.lookup(p).product_name).to be_a(String)
+    end
+  end
+
+  it "returns nil for unset parameters" do
+    expect(PRODUCT_MATRIX.lookup("chef").ctl_command).to be_nil
+  end
+
+  context "for chef-server" do
+    let(:product_name) { "chef-server" }
+
+    context "for version > 12.0.0" do
+      let(:version) { "12.0.5" }
+
+      it "should return correct package_name" do
+        expect(package_name).to eq("chef-server-core")
+      end
+    end
+
+    context "for latest" do
+      let(:version) { :latest }
+
+      it "should return correct package_name" do
+        expect(package_name).to eq("chef-server-core")
+      end
+    end
+
+    context "for < 12.0.0, > 11.0.0" do
+      let(:version) { "11.5.0" }
+
+      it "should return correct package_name" do
+        expect(package_name).to eq("chef-server")
+      end
+    end
+  end
+
+  context "for manage" do
+    let(:product_name) { "manage" }
+
+    context "for version > 2.0.0" do
+      let(:version) { "2.0.5" }
+
+      it "should return correct package_name" do
+        expect(package_name).to eq("chef-manage")
+      end
+
+      it "should return correct ctl_command" do
+        expect(ctl_command).to eq("chef-manage-ctl")
+      end
+    end
+
+    context "for latest" do
+      let(:version) { :latest }
+
+      it "should return correct package_name" do
+        expect(package_name).to eq("chef-manage")
+      end
+
+      it "should return correct ctl_command" do
+        expect(ctl_command).to eq("chef-manage-ctl")
+      end
+    end
+
+    context "for < 2.0.0" do
+      let(:version) { "1.5.0" }
+
+      it "should return correct package_name" do
+        expect(package_name).to eq("opscode-manage")
+      end
+
+      it "should return correct ctl_command" do
+        expect(ctl_command).to eq("opscode-manage-ctl")
+      end
+    end
+  end
+
+  context "for push-server" do
+    let(:product_name) { "push-server" }
+
+    context "for version > 2.0.0" do
+      let(:version) { "2.0.5" }
+
+      it "should return correct package_name" do
+        expect(package_name).to eq("push-jobs-server")
+      end
+
+      it "should return correct ctl_command" do
+        expect(ctl_command).to eq("push-jobs-server-ctl")
+      end
+    end
+
+    context "for latest" do
+      let(:version) { :latest }
+
+      it "should return correct package_name" do
+        expect(package_name).to eq("push-jobs-server")
+      end
+
+      it "should return correct ctl_command" do
+        expect(ctl_command).to eq("push-jobs-server-ctl")
+      end
+    end
+
+    context "for < 2.0.0" do
+      let(:version) { "1.5.0" }
+
+      it "should return correct package_name" do
+        expect(package_name).to eq("opscode-push-jobs-server")
+      end
+
+      it "should return correct ctl_command" do
+        expect(ctl_command).to eq("opscode-push-jobs-server-ctl")
+      end
+    end
+  end
+
+  context "for push-client" do
+    let(:product_name) { "push-client" }
+
+    context "for version > 1.3.0" do
+      let(:version) { "1.3.5" }
+
+      it "should return correct package_name" do
+        expect(package_name).to eq("push-jobs-client")
+      end
+    end
+
+    context "for latest" do
+      let(:version) { :latest }
+
+      it "should return correct package_name" do
+        expect(package_name).to eq("push-jobs-client")
+      end
+    end
+
+    context "for < 1.3.0" do
+      let(:version) { "1.2.0" }
+
+      it "should return correct package_name" do
+        expect(package_name).to eq("opscode-push-jobs-client")
+      end
+    end
+  end
+end

--- a/spec/mixlib/install/product_spec.rb
+++ b/spec/mixlib/install/product_spec.rb
@@ -53,8 +53,8 @@ context "Mixlib::Install::Product" do
     end
 
     it "accepts and returns the value correctly with a version" do
-      product.version("110")
-      expect(product.package_name).to eq("my-version-110")
+      product.version("11.0.0")
+      expect(product.package_name).to eq("my-version-11.0.0")
     end
 
     it "returns nil for unset properties" do


### PR DESCRIPTION
This PR moves [product matrix](https://github.com/chef-cookbooks/chef-ingredient/blob/master/PRODUCT_MATRIX.md) and its helper methods from chef-cookbooks/chef-ingredient to here. A few things to keep in mind while reviewing:

1. I do not think the `package_name` column in the `PRODUCT_MATRIX.md` makes sense. I think we should add a description column for it to be more useful for the end user. But I did not do that and copied over only what we have. 
2. @jtimberman can you double check the version based logic in the matrix. I have double checked it but just in case :smile: 

/cc: @chef/engineering-services, @thommay 