### PR TITLE
Windows Support

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,10 +1,12 @@
 source "https://rubygems.org"
 
 gem "mixlib-install", path: "../"
-gem "test-kitchen", github: "sersut/test-kitchen"
+gem "test-kitchen", github: "sersut/test-kitchen", branch: "sersut/mixlib-install-update"
 gem "chef-acceptance", github: "chef/chef-acceptance"
 gem "pry"
 
 group(:development) do
   gem "kitchen-vagrant"
+  gem "windows_chef_zero"
+  gem "winrm-transport"
 end

--- a/acceptance/Gemfile.lock
+++ b/acceptance/Gemfile.lock
@@ -1,16 +1,16 @@
 GIT
   remote: git://github.com/chef/chef-acceptance.git
-  revision: e28d67891b0359af83836ec55c91eb07e8b062d1
+  revision: 47f5f54e561981802122168ca01ae03907965312
   specs:
     chef-acceptance (0.2.0)
       thor (~> 0.19)
 
 GIT
   remote: git://github.com/sersut/test-kitchen.git
-  revision: 5e4fa6baff5d51dc983be3f7b67ffe1bcbf2a8d2
+  revision: fd05389ec556fdcac96b92b1aea2a9ed48802e75
+  branch: sersut/mixlib-install-update
   specs:
     test-kitchen (1.4.3.dev.0)
-      mixlib-install (~> 0.7)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
       net-ssh (~> 2.7, < 2.10)
@@ -28,22 +28,52 @@ GEM
   remote: https://rubygems.org/
   specs:
     artifactory (2.3.2)
+    builder (3.2.2)
     coderay (1.1.0)
+    ffi (1.9.10)
+    gssapi (1.2.0)
+      ffi (>= 1.0.1)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
+    httpclient (2.7.0.1)
     kitchen-vagrant (0.19.0)
       test-kitchen (~> 1.4)
+    little-plugger (1.1.4)
+    logging (2.0.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
     method_source (0.8.2)
-    mixlib-shellout (2.2.3)
+    mixlib-shellout (2.2.5)
     mixlib-versioning (1.1.0)
+    multi_json (1.11.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
+    nori (2.6.0)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    rubyntlm (0.4.0)
+    rubyzip (1.1.7)
     safe_yaml (1.0.4)
     slop (3.6.0)
     thor (0.19.1)
+    uuidtools (2.1.5)
+    windows_chef_zero (2.0.0)
+      test-kitchen (>= 1.2.1)
+    winrm (1.3.6)
+      builder (>= 2.1.2)
+      gssapi (~> 1.2)
+      gyoku (~> 1.0)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (>= 1.6.1, < 3.0)
+      nori (~> 2.0)
+      rubyntlm (~> 0.4.0)
+      uuidtools (~> 2.1.2)
+    winrm-transport (1.0.3)
+      rubyzip (~> 1.1, >= 1.1.7)
+      winrm (~> 1.3)
 
 PLATFORMS
   ruby
@@ -54,6 +84,8 @@ DEPENDENCIES
   mixlib-install!
   pry
   test-kitchen!
+  windows_chef_zero
+  winrm-transport
 
 BUNDLED WITH
    1.10.6

--- a/acceptance/current/.acceptance/acceptance-cookbook/recipes/provision.rb
+++ b/acceptance/current/.acceptance/acceptance-cookbook/recipes/provision.rb
@@ -1,1 +1,3 @@
-log 'provision recipe'
+execute 'kitchen converge' do
+  cwd node['chef-acceptance']['suite-dir']
+end

--- a/acceptance/current/.kitchen.yml
+++ b/acceptance/current/.kitchen.yml
@@ -23,12 +23,9 @@ platforms:
   # - name: macosx-10.10
   #   driver:
   #     box: chef/macosx-10.10 # private
-  # - name: windows-7-professional
-  #   provisioner:
-  #     name: windows_chef_zero
-  #     require_chef_omnibus: 11.12.4
-  #   driver:
-  #     box: chef/windows-7-professional # private
+  - name: windows-server-2012r2-standard
+    driver:
+      box: chef/windows-server-2012r2-standard # private
 
 suites:
   - name: mixlib-install-chef

--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -56,10 +56,13 @@ module Mixlib
     # @return [String] the installation directory for the project
     #
     def root
-      # TODO: Support root as "$env:systemdrive\\opscode\\chef" when on windows.
       # This only works for chef and chefdk but they are the only projects
       # we are supporting as of now.
-      "/opt/#{options.product_name}"
+      if options.for_ps1?
+        "$env:systemdrive\\opscode\\#{options.product_name}"
+      else
+        "/opt/#{options.product_name}"
+      end
     end
 
     #
@@ -72,7 +75,12 @@ module Mixlib
       # install directory which can be different than the product name (e.g.
       # chef-server -> /opt/opscode). But this is OK for now since
       # chef & chefdk are the only supported products.
-      version_manifest_file = "/opt/#{options.product_name}/version-manifest.json"
+      version_manifest_file = if options.for_ps1?
+        "$env:systemdrive\\opscode\\#{options.product_name}\\version-manifest.json"
+      else
+        "/opt/#{options.product_name}/version-manifest.json"
+      end
+
       if File.exist? version_manifest_file
         JSON.parse(File.read(version_manifest_file))["build_version"]
       end

--- a/lib/mixlib/install/generator.rb
+++ b/lib/mixlib/install/generator.rb
@@ -16,12 +16,17 @@
 #
 
 require "mixlib/install/generator/bourne"
+require "mixlib/install/generator/powershell"
 
 module Mixlib
   class Install
     class Generator
       def self.install_command(options)
-        Bourne.new(options).install_command
+        if options.for_ps1?
+          PowerShell.new(options).install_command
+        else
+          Bourne.new(options).install_command
+        end
       end
     end
   end

--- a/lib/mixlib/install/generator/powershell.rb
+++ b/lib/mixlib/install/generator/powershell.rb
@@ -1,0 +1,67 @@
+#
+# Copyright:: Copyright (c) 2015 Chef, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Mixlib
+  class Install
+    class Generator
+      class PowerShell
+        attr_reader :options
+
+        def initialize(options)
+          @options = options
+        end
+
+        def install_command
+          install_project_module = []
+          install_project_module << get_script(:helpers)
+          if options.for_artifactory?
+            raise "not implemented yet"
+            # install_project_module << get_script(:get_project_metadata_for_artifactory)
+          else
+            install_project_module << get_script(:get_project_metadata)
+          end
+          install_project_module << get_script(:install_project)
+
+          install_command = []
+          install_command << ps1_modularize(install_project_module.join("\n"), "Omnitruck")
+          install_command << render_command
+          install_command.join("\n\n")
+        end
+
+        def ps1_modularize(module_body, module_name)
+          ps1_module = []
+          ps1_module << "new-module -name #{module_name} -scriptblock {"
+          ps1_module << module_body
+          ps1_module << "}"
+          ps1_module.join("\n")
+        end
+
+        def render_command
+          <<EOS
+install -project #{options.product_name} \
+-version #{options.product_version} \
+-channel #{options.channel}
+EOS
+        end
+
+        def get_script(name)
+          File.read(File.join(File.dirname(__FILE__), "powershell/scripts/#{name}.ps1"))
+        end
+      end
+    end
+  end
+end

--- a/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1
@@ -1,0 +1,78 @@
+function Get-ProjectMetadata {
+  <#
+    .SYNOPSIS
+    Get metadata for a Chef Software, Inc. project
+    .DESCRIPTION
+    Get metadata for project
+    .EXAMPLE
+    iex (new-object net.webclient).downloadstring('https:/omnitruck.chef.io/install.ps1'); Get-ProjectMetadata -project chef -channel stable
+
+    Gets the download url, MD5 checksum, and SHA256 checksum for the latest stable release of Chef.
+    .EXAMPLE
+    iex (irm 'https://omnitruck.chef.io/install.ps1'); Get-ProjectMetadata -project chefdk -channel stable -version 0.8.0
+
+    Gets the download url, MD5 checksum, and SHA256 checksum for ChefDK 0.8.0.
+  #>
+  [cmdletbinding()]
+  param (
+    # Base url to retrieve metadata from.
+    [uri]$base_server_uri = 'http://omnitruck.chef.io/',
+    [string]
+    # Project to install
+    # chef - Chef Client
+    # chefdk - Chef Development Kit
+    # angrychef - AngryChef
+    # server and container are not valid windows targets
+    [validateset('chef', 'chefdk', 'angrychef')]
+    [string]
+    $project = 'chef',
+    # Version of the application to install
+    # This parameter is optional, if not supplied it will provide the latest version,
+    # and if an iteration number is not specified, it will grab the latest available iteration.
+    # Partial version numbers are also acceptable (using v=11
+    # will grab the latest 11.x client which matches the other flags).
+    [string]
+    $version,
+    # Release channel to install from
+    [validateset('current', 'stable')]
+    [string]
+    $channel = 'stable'
+  )
+
+  # PowerShell is only on Windows ATM
+  $platform = 'windows'
+  Write-Verbose "Platform: $platform"
+
+  # TODO: No Win10 build endpoint yet
+  switch -regex ((get-wmiobject win32_operatingsystem).version) {
+    '10\.0\.\d+' {$platform_version = '2012r2'}
+    '6\.3\.\d+'  {$platform_version = '2012r2'}
+    '6\.2\.\d+'  {$platform_version = '2012'}
+    '6\.1\.\d+'  {$platform_version = '2008r2'}
+    '6\.0\.\d+'  {$platform_version = '2008'}
+  }
+  Write-Verbose "Platform Version: $platform_version"
+
+  # TODO: When we ship a 64 bit ruby for Windows.
+  $machine = 'x86_64'
+  Write-Verbose "Machine: $machine"
+  Write-Verbose "Project: $project"
+
+  $metadata_base_url = "$($channel)/$($project)/metadata"
+  $metadata_array = ("?v=$($version)",
+    "p=$platform",
+    "pv=$platform_version",
+    "m=$machine")
+  $metadata_base_url += [string]::join('&', $metadata_array)
+  $metadata_url = new-uri $base_server_uri $metadata_base_url
+
+  Write-Verbose "Downloading $project details from $metadata_url"
+  $package_metadata = (Get-WebContent $metadata_url).trim() -split '\n' |
+    foreach { $hash = @{} } {$key, $value = $_ -split '\s+'; $hash.Add($key, $value)} {$hash}
+
+  Write-Verbose "Project details: "
+  foreach ($key in $package_metadata.keys) {
+    Write-Verbose "`t$key = $($package_metadata[$key])"
+  }
+  $package_metadata
+}

--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1
@@ -1,0 +1,69 @@
+function New-Uri {
+  param ($baseuri, $newuri)
+
+  new-object System.Uri $baseuri, $newuri
+}
+
+function Get-WebContent {
+  param ($uri, $filepath)
+  $proxy = New-Object -TypeName System.Net.WebProxy
+  $wc = new-object System.Net.WebClient
+  $proxy.Address = $env:http_proxy
+  $wc.Proxy = $proxy
+
+  try {
+    if ([string]::IsNullOrEmpty($filepath)) {
+      $wc.downloadstring($uri)
+    }
+    else {
+      $wc.downloadfile($uri, $filepath)
+    }
+  }
+  catch {
+    $exception = $_.Exception
+    Write-Host "There was an error: "
+    do {
+      Write-Host "`t$($exception.message)"
+      $exception = $exception.innerexception
+    } while ($exception)
+    throw "Failed to download from $uri."
+  }
+}
+
+function Test-ProjectPackage {
+  [cmdletbinding()]
+  param ($Path, $Algorithm = 'SHA256', $Hash)
+
+  if (-not (get-command get-filehash))   {
+    function disposable($o){($o -is [IDisposable]) -and (($o | get-member | foreach-object {$_.name}) -contains 'Dispose')}
+    function use($obj, [scriptblock]$sb){try {& $sb} catch [exception]{throw $_} finally {if (disposable $obj) {$obj.Dispose()}} }
+    function Get-FileHash ($Path, $Algorithm) {
+      $Path = (resolve-path $path).providerpath
+      $hash = @{Algorithm = $Algorithm; Path = $Path}
+      if ($Algorithm -like 'MD5') {
+        use ($c = New-Object -TypeName Security.Cryptography.MD5CryptoServiceProvider) {
+          use ($in = (gi $path).OpenRead()) {
+            $hash.Hash = ([BitConverter]::ToString($c.ComputeHash($in))).Replace("-", "").ToUpper()
+          }
+        }
+      }
+      elseif ($Algorithm -like 'SHA256') {
+        use ($c = New-Object -TypeName Security.Cryptography.SHA256CryptoServiceProvider) {
+          use ($in = (gi $path).OpenRead()) {
+            $hash.Hash = ([BitConverter]::ToString($c.ComputeHash($in))).Replace("-", "").ToUpper()
+          }
+        }
+      }
+      new-object PSObject -Property $hash
+    }
+  }
+  Write-Verbose "Testing the $Algorithm hash for $path."
+  $ActualHash = (Get-FileHash -Algorithm $Algorithm -Path $Path).Hash.ToLower()
+  Write-Verbose "`tDesired Hash - '$hash'"
+  Write-Verbose "`tActual Hash  - '$ActualHash'"
+  $Valid = $ActualHash -eq $Hash
+  if (-not $Valid) {
+    Write-Error "Failed to validate the downloaded installer.  The expected $Algorithm hash was '$Hash' and the actual hash was '$ActualHash' for $path"
+  }
+  return $Valid
+}

--- a/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
@@ -1,0 +1,91 @@
+function Install-Project {
+  <#
+    .SYNOPSIS
+    Install a Chef Software, Inc. product
+    .DESCRIPTION
+    Install a Chef Software, Inc. product
+    .EXAMPLE
+    iex (new-object net.webclient).downloadstring('https:/omnitruck.chef.io/install.ps1'); Install-Project -project chef -channel stable
+
+    Installs the latest stable version of Chef.
+    .EXAMPLE
+    iex (irm 'https://omnitruck.chef.io/install.ps1'); Install-Project -project chefdk -channel current
+
+    Installs the latest integration build of the Chef Development Kit
+  #>
+  [cmdletbinding(SupportsShouldProcess=$true)]
+  param (
+    # Project to install
+    # chef - Chef Client
+    # chefdk - Chef Development Kit
+    # angrychef - AngryChef
+    # server and container are not valid windows targets
+    [validateset('chef', 'chefdk', 'angrychef')]
+    [string]
+    $project = 'chef',
+    # Release channel to install from
+    [validateset('current', 'stable')]
+    [string]
+    $channel = 'stable',
+    # Version of the application to install
+    # This parameter is optional, if not supplied it will provide the latest version,
+    # and if an iteration number is not specified, it will grab the latest available iteration.
+    # Partial version numbers are also acceptable (using v=11
+    # will grab the latest 11.x client which matches the other flags).
+    [string]
+    $version,
+    # Full path for the downloaded installer.
+    [string]
+    $filename,
+    # Full path to the location to download the installer
+    [string]
+    $download_directory = $env:temp
+  )
+
+  $package_metadata = Get-ProjectMetadata -project $project -channel $channel -version $version
+
+  if (-not [string]::IsNullOrEmpty($filename)) {
+    $download_directory = split-path $filename
+    $filename = split-path $filename -leaf
+    if ([string]::IsNullOrEmpty($download_directory)) {
+      $download_directory = $pwd
+    }
+  }
+  else {
+    $filename = ($package_metadata.url -split '/')[-1]
+  }
+  Write-Verbose "Download directory: $download_directory"
+  Write-Verbose "Filename: $filename"
+
+  if (-not (test-path $download_directory)) {
+    mkdir $download_directory
+  }
+  $download_directory = (resolve-path $download_directory).providerpath
+  $download_destination = join-path $download_directory $filename
+
+  if ((test-path $download_destination) -and
+    (Test-ProjectPackage -Path $download_destination -Algorithm 'SHA256' -Hash $package_metadata.sha256 -ea SilentlyContinue)){
+    Write-Verbose "Found existing valid installer at $download_destination."
+  }
+  else {
+    if ($pscmdlet.ShouldProcess("$($package_metadata.url)", "Download $project")) {
+      Write-Verbose "Downloading $project from $($package_metadata.url) to $download_destination."
+      Get-WebContent $package_metadata.url -filepath $download_destination
+    }
+  }
+
+  if ($pscmdlet.ShouldProcess("$download_destination", "Installing")){
+    if (Test-ProjectPackage -Path $download_destination -Algorithm 'SHA256' -Hash $package_metadata.sha256) {
+      Write-Host "Installing $project from $download_destination"
+      $p = Start-Process -FilePath "msiexec" -ArgumentList "/qn /i $download_destination" -Passthru -Wait
+      if ($p.ExitCode -ne 0) {
+        throw "msiexec was not successful. Received exit code $($p.ExitCode)"
+      }
+    }
+    else {
+      throw "Failed to validate the downloaded installer for $project."
+    }
+  }
+}
+set-alias install -value Install-Project
+export-modulemember -function 'Install-Project','Get-ProjectMetadata' -alias 'install'

--- a/spec/mixlib/install/generator_spec.rb
+++ b/spec/mixlib/install/generator_spec.rb
@@ -21,19 +21,78 @@ require "mixlib/install"
 context "Mixlib::Install::Generator" do
   let(:channel) { nil }
 
+  let(:options) {
+    {
+      product_name: "chef",
+      channel: channel,
+      product_version: "latest"
+    }
+  }
+
   let(:install_script) {
-    Mixlib::Install.new(product_name: "chef",
-                        channel: channel,
-                        product_version: "latest").install_command
+    Mixlib::Install.new(options).install_command
   }
 
   context "for :stable channel" do
     let(:channel) { :stable }
+    let(:add_options) { {} }
 
-    it "outputs the install_command" do
-      expect(install_script).to be_a(String)
-      expect(install_script).to start_with("#!/bin/sh")
-      expect(install_script).to include('install_file $filetype "$download_filename"')
+    shared_examples_for "the correct sh script" do
+      it "generates an sh script" do
+        options.merge!(add_options)
+        expect(install_script).to be_a(String)
+        expect(install_script).to start_with("#!/bin/sh")
+        expect(install_script).to include('install_file $filetype "$download_filename"')
+      end
+    end
+
+    context "default shell type" do
+      it_behaves_like "the correct sh script"
+    end
+
+    context "sh shell type" do
+      let(:add_options) {
+        {
+          shell_type: :sh
+        }
+      }
+
+      it_behaves_like "the correct sh script"
+    end
+
+    context "for windows" do
+      shared_examples_for "the correct ps1 script" do
+        it "generates a ps1 script" do
+          options.merge!(add_options)
+
+          expect(install_script).to be_a(String)
+          expect(install_script).to start_with("new-module -name Omnitruck -scriptblock")
+          expect(install_script).to include("set-alias install -value Install-Project")
+          expect(install_script).to end_with("install -project #{options[:product_name]} -version #{options[:product_version]} -channel #{options[:channel]}\n")
+        end
+      end
+
+      context "when platform is set" do
+        let(:add_options) {
+          {
+            platform: "windows",
+            platform_version: "2012r2",
+            architecture: "x86_64"
+          }
+        }
+
+        it_behaves_like "the correct ps1 script"
+      end
+
+      context "when shell_type is set" do
+        let(:add_options) {
+          {
+            shell_type: :ps1
+          }
+        }
+
+        it_behaves_like "the correct ps1 script"
+      end
     end
   end
 end

--- a/spec/mixlib/install/options_spec.rb
+++ b/spec/mixlib/install/options_spec.rb
@@ -26,6 +26,7 @@ context "Mixlib::Install::Options" do
   let(:platform) { nil }
   let(:platform_version) { nil }
   let(:architecture) { nil }
+  let(:shell_type) { nil }
 
   context "for invalid product name option" do
     let(:product_name) { "foo" }
@@ -93,6 +94,14 @@ context "Mixlib::Install::Options" do
       it "does not raise an error" do
         expect { Mixlib::Install.new(base_options) }.to_not raise_error
       end
+    end
+  end
+
+  context "for shell type options" do
+    let(:shell_type) { :foo }
+
+    it "raises invalid shell type error" do
+      expect { Mixlib::Install.new(shell_type: shell_type) }.to raise_error(Mixlib::Install::Options::InvalidOptions, /Unknown shell type/)
     end
   end
 end


### PR DESCRIPTION
first pass for supporting windows install scripts for omnitruck.

removed nightlies and prerelease switches

artifactory urls for unstable channel not yet implemented

todo:
- ~~optimize powershell install_command~~
- ~~refactor paths for Install #root and #current_version methods (and make sure they are correct)~~
- ~~validate with chef-acceptance (kitchen)~~
- ~~implement in chef-ingredient~~



