### PR TITLE
Remove version checks for push server 2.0

### DIFF
--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -239,12 +239,8 @@ PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
 
   product "push-server" do
     product_name "Chef Push Server"
-    package_name do |v|
-      v < version_for("2.0.0") ? "opscode-push-jobs-server" : "push-jobs-server"
-    end
-    ctl_command do |v|
-      v < version_for("2.0.0") ? "opscode-push-jobs-server-ctl" : "push-jobs-server-ctl"
-    end
+    package_name "opscode-push-jobs-server"
+    ctl_command "opscode-push-jobs-server-ctl"
     config_file "/etc/opscode-push-jobs-server/opscode-push-jobs-server.rb"
   end
 

--- a/spec/mixlib/install/product_spec.rb
+++ b/spec/mixlib/install/product_spec.rb
@@ -187,27 +187,15 @@ context "PRODUCT_MATRIX" do
   context "for push-server" do
     let(:product_name) { "push-server" }
 
-    context "for version > 2.0.0" do
-      let(:version) { "2.0.5" }
-
-      it "should return correct package_name" do
-        expect(package_name).to eq("push-jobs-server")
-      end
-
-      it "should return correct ctl_command" do
-        expect(ctl_command).to eq("push-jobs-server-ctl")
-      end
-    end
-
     context "for latest" do
       let(:version) { :latest }
 
       it "should return correct package_name" do
-        expect(package_name).to eq("push-jobs-server")
+        expect(package_name).to eq("opscode-push-jobs-server")
       end
 
       it "should return correct ctl_command" do
-        expect(ctl_command).to eq("push-jobs-server-ctl")
+        expect(ctl_command).to eq("opscode-push-jobs-server-ctl")
       end
     end
 


### PR DESCRIPTION
At this time we don't have a Push Server 2.0 - the "latest" is 1.1.6.
The logic for :latest setting the version to 1000.1000.1000 means
we'll always be > 2.0.