### PR TITLE
Ability to render install.sh script.

### DIFF
--- a/acceptance/Gemfile.lock
+++ b/acceptance/Gemfile.lock
@@ -20,7 +20,7 @@ GIT
 PATH
   remote: ../
   specs:
-    mixlib-install (0.8.0.alpha.0)
+    mixlib-install (0.8.0.alpha.1)
       artifactory (~> 2.3.0)
       mixlib-versioning (~> 1.1.0)
 

--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -22,6 +22,7 @@ require "mixlib/versioning"
 require "mixlib/install/backend"
 require "mixlib/install/options"
 require "mixlib/install/generator"
+require "mixlib/install/generator/bourne"
 
 module Mixlib
   class Install
@@ -87,6 +88,17 @@ module Mixlib
       available_ver = Mixlib::Versioning.parse(artifact_info.first.version)
       current_ver = Mixlib::Versioning.parse(current_version)
       (available_ver > current_ver)
+    end
+
+    #
+    # Returns the install.sh script
+    # Supported context parameters:
+    # ------------------
+    # base_url [String]
+    #   url pointing to the omnitruck to be queried by the script.
+    #
+    def self.install_sh(context = {})
+      Mixlib::Install::Generator::Bourne.install_sh(context)
     end
   end
 end

--- a/lib/mixlib/install/generator/bourne/scripts/fetch_metadata.sh.erb
+++ b/lib/mixlib/install/generator/bourne/scripts/fetch_metadata.sh.erb
@@ -21,7 +21,7 @@
 echo "Getting information for $project $channel $version for $platform..."
 
 metadata_filename="$tmp_dir/metadata.txt"
-metadata_url="https://omnitruck.chef.io/$channel/$project/metadata?v=$version&p=$platform&pv=$platform_version&m=$machine"
+metadata_url="<%= base_url %>$channel/$project/metadata?v=$version&p=$platform&pv=$platform_version&m=$machine"
 
 do_download "$metadata_url"  "$metadata_filename"
 

--- a/lib/mixlib/install/generator/bourne/scripts/script_cli_parameters.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/script_cli_parameters.sh
@@ -1,0 +1,36 @@
+# script_cli_parameters.sh
+############
+# This section reads the CLI parameters for the install script and translates
+#   them to the local parameters to be used later by the script.
+#
+# Outputs:
+# $version: Requested version to be installed.
+# $channel: Channel to install the product from
+# $project: Project to be installed
+# $cmdline_filename: Name of the package downloaded on local disk.
+# $cmdline_dl_dir: Name of the directory downloaded package will be saved to on local disk.
+############
+
+# Defaults
+channel="stable"
+project="chef"
+
+while getopts pnv:c:f:P:d: opt
+do
+  case "$opt" in
+
+    v)  version="$OPTARG";;
+    c)  channel="$OPTARG";;
+    p)  channel="current";; # compat for prerelease option
+    n)  channel="current";; # compat for nightlies option
+    f)  cmdline_filename="$OPTARG";;
+    P)  project="$OPTARG";;
+    d)  cmdline_dl_dir="$OPTARG";;
+    \?)   # unknown flag
+      echo >&2 \
+      "usage: $0 [-P project] [-c release_channel] [-v version] [-f filename | -d download_dir]"
+      exit 1;;
+  esac
+done
+
+shift `expr $OPTIND - 1`

--- a/spec/mixlib/install_spec.rb
+++ b/spec/mixlib/install_spec.rb
@@ -119,6 +119,32 @@ context "Mixlib::Install" do
         expect(installer.upgrade_available?).to eq(true)
       end
     end
+  end
 
+  context "install_sh" do
+    let(:base_url) { nil }
+
+    let(:install_sh) do
+      options = {}.tap do |opt|
+        opt[:base_url] = base_url if base_url
+      end
+      Mixlib::Install.install_sh(options)
+    end
+
+    it "should render a script with cli parameters" do
+      expect(install_sh).to include("while getopts pnv:c:f:P:d: opt")
+    end
+
+    context "with custom base_url" do
+      let(:base_url) { "https://my.omnitruck.com/" }
+
+      it "should render with the given base_url" do
+        expect(install_sh).to include(base_url)
+      end
+    end
+
+    it "should render with default base_url if one is not given" do
+      expect(install_sh).to include("https://omnitruck.chef.io")
+    end
   end
 end


### PR DESCRIPTION
This PR adds the ability to render `install.sh` script to be used by omnitruck. See https://github.com/chef/omnitruck/pull/158 for the required changes on the omnibus side. 

The newly rendered script will be slightly different than the old script. Here are the main three differences:

* Function helpers are collected at the beginning of the script which relocated some sections of the script, the biggest being fetch_metadata section.
* Comments / documentation for clarity.
* Baked the http/https check for solaris into the download functions.

You can also see https://gist.github.com/sersut/c9851cde22b5e4cbd2ec which contains the diff data and an example of scripts.

/cc: @chef/engineering-services, @thommay, @lamont-granquist, @jaym 