### PR TITLE
wip: configurable repo for direct use of the Artifactory Backend

### DIFF
--- a/lib/mixlib/install/backend/artifactory.rb
+++ b/lib/mixlib/install/backend/artifactory.rb
@@ -27,8 +27,6 @@ module Mixlib
       class Artifactory
         ARTIFACTORY_ENDPOINT = "http://artifactory.chef.co".freeze
 
-        ARTIFACTORY_REPOSITORY = "omnibus-unstable-local".freeze
-
         attr_reader :options
         attr_reader :client
 
@@ -41,8 +39,8 @@ module Mixlib
           begin
             results = client.get("/api/search/prop", params, headers)["results"]
           rescue Errno::ETIMEDOUT => e
-            raise e, "unstable channel uses endpoint #{ARTIFACTORY_ENDPOINT} \
-which is currently only accessible through Chef's internal network."
+            raise e, "Artifactory endpoint '#{ARTIFACTORY_ENDPOINT}' \
+is currently only accessible through Chef's internal network."
           end
 
           if options.platform
@@ -70,7 +68,7 @@ which is currently only accessible through Chef's internal network."
 
         def params
           params = {
-            "repos" => ARTIFACTORY_REPOSITORY,
+            "repos" => "omnibus-#{options.channel}-local",
             "omnibus.version" => options.product_version
           }
 

--- a/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
@@ -47,7 +47,7 @@ function Install-Project {
     $nightlies
   )
 
-  $package_metadata = Get-ProjectMetadata -project $project -channel $channel -version $version -download_directory $download_directory -prerelease:$prerelease -nightlies:$nightlies
+  $package_metadata = Get-ProjectMetadata -project $project -channel $channel -version $version -prerelease:$prerelease -nightlies:$nightlies
 
   if (-not [string]::IsNullOrEmpty($filename)) {
     $download_directory = split-path $filename

--- a/spec/mixlib/install/backend/artifactory_spec.rb
+++ b/spec/mixlib/install/backend/artifactory_spec.rb
@@ -1,0 +1,69 @@
+#
+# Author:: Patrick Wright (<patrick@chef.io>)
+# Copyright:: Copyright (c) 2015 Chef, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "mixlib/install/backend/artifactory"
+
+context "Mixlib::Install::Backend::Artifactory", focus: true do
+  let(:product_name) { "chef" }
+  let(:product_version) { nil }
+  let(:channel) { nil }
+
+  let(:opts) {
+    {
+      product_name: product_name,
+      product_version: product_version,
+      channel: channel
+    }
+  }
+
+  let(:options) { Mixlib::Install::Options.new(opts) }
+
+  let(:artifactory) { Mixlib::Install::Backend::Artifactory.new(options) }
+
+  context "with unstable channel" do
+    let(:channel) { :unstable }
+    let(:product_version) { "12.5.1+20151210002019" }
+
+    it "pulls unstable artifacts" do
+      puts artifactory.info
+      # expect(artifactory.info.size).to be > 0
+    end
+  end
+
+  context "with stable channel" do
+    let(:channel) { :stable }
+    let(:product_version) { "12.5.1" }
+
+    it "pulls stable artifacts" do
+      puts artifactory.info
+      # expect(artifactory.info.size).to be > 0
+    end
+  end
+
+  context "with current channel" do
+    let(:channel) { :current }
+    let(:product_version) { "12.5.1+20151210002019" }
+
+    it "pulls current artifacts" do
+      puts artifactory.info
+      # expect(artifactory.info.size).to be > 0
+    end
+  end
+
+end

--- a/spec/mixlib/install_spec.rb
+++ b/spec/mixlib/install_spec.rb
@@ -160,7 +160,7 @@ context "Mixlib::Install" do
 
     it "should render a script with cli & backcompat parameters" do
       expect(install_ps1).not_to include("install -project")
-      expect(install_ps1).to include("Get-ProjectMetadata -project $project -channel $channel -version $version -download_directory $download_directory -prerelease:$prerelease -nightlies:$nightlies")
+      expect(install_ps1).to include("Get-ProjectMetadata -project $project -channel $channel -version $version -prerelease:$prerelease -nightlies:$nightlies")
     end
 
     context "with custom base_url" do


### PR DESCRIPTION
Something that came up in #engineering-services.  Steven D and Seth discussion about mixlib-install and being able to use the Artifactory Backend directly for local script usage.

Simple change, but really needs to support `:latest` before it's truly useful.

Not meant to be a working branch, just an example for later.