### PR TITLE
support latest version keyword for unstable channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,16 @@ artifacts.first.url
 # => "http://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12.5.1%2B20151009083009-1.dmg"
 ```
 
+## Unstable channel
+The `:unstable` channel is currently only available when connected to Chef's internal network.
+Configure Artifactory access by setting the following environment variables:
+```
+export ARTIFACTORY_USERNAME='username'
+export ARTIFACTORY_PASSWORD='password'
+```
 
-## Test
-Some tests are tagged `:unstable` and can only run when connected to Chef's internal network.  These are excluded by default.  To run the `:unstable` tests run: `bundle exec rspec --tag unstable`.
+### Unstable channel specs
+Some spec examples are tagged `:unstable` and can only run when connected to Chef's internal network.  These are excluded by default.  To run the `:unstable` tests run: `bundle exec rspec --tag unstable`.
 
 ## Contributing
 

--- a/acceptance/unstable/.kitchen.yml
+++ b/acceptance/unstable/.kitchen.yml
@@ -28,13 +28,13 @@ suites:
   - name: chef-unstable-install
     provisioner:
       product_name: chef
-      product_version: 12.5.1+20151210002019
+      product_version: latest
       channel: unstable
     run_list:
   - name: chefdk-unstable-install
     excludes: [ 'freebsd-10.0' ]
     provisioner:
       product_name: chefdk
-      product_version: 0.10.0+20151209030614
+      product_version: latest
       channel: unstable
     run_list:

--- a/lib/mixlib/install/generator/powershell.rb
+++ b/lib/mixlib/install/generator/powershell.rb
@@ -65,14 +65,26 @@ module Mixlib
         end
 
         def artifactory_urls
-          artifacts = Mixlib::Install::Backend::Artifactory.new(options).info
-          get_script("get_project_metadata_for_artifactory.ps1", artifacts: artifacts)
+          get_script("get_project_metadata_for_artifactory.ps1",
+                     artifacts: artifacts)
+        end
+
+        def artifacts
+          @artifacts ||= Mixlib::Install::Backend::Artifactory.new(options).info
+        end
+
+        def product_version
+          if options.for_artifactory?
+            options.resolved_version(artifacts)
+          else
+            options.product_version
+          end
         end
 
         def render_command
           <<EOS
 install -project #{options.product_name} \
--version #{options.product_version} \
+-version #{product_version} \
 -channel #{options.channel}
 EOS
         end

--- a/spec/mixlib/install/backend_spec.rb
+++ b/spec/mixlib/install/backend_spec.rb
@@ -40,10 +40,12 @@ context "Mixlib::Install::Backend" do
     ).artifact_info
   }
 
+  let(:expected_protocol) { "https://" }
+
   shared_examples_for "the right artifact info" do
     it "gives the right url artifact info" do
       if !expected_info.key?(:url)
-        expect(info.url).to match "https://"
+        expect(info.url).to match expected_protocol
       else
         expect(info.url).to match expected_info[:url]
       end
@@ -109,7 +111,7 @@ context "Mixlib::Install::Backend" do
 
     it "has correctly formed url" do
       info.each do |artifact_info|
-        expect(artifact_info.url).to match "http"
+        expect(artifact_info.url).to match expected_protocol
       end
     end
 
@@ -297,21 +299,21 @@ context "Mixlib::Install::Backend" do
 
         context "with a major.minor product version" do
           let(:product_version) { "12.4" }
-          let(:expected_version) { /^12.4.\d\+[0-9]{14}$/ }
+          let(:expected_version) { /^12.4.\d/ }
 
           it_behaves_like "the right artifact list info"
         end
 
         context "with a major product version" do
           let(:product_version) { "12" }
-          let(:expected_version) { /^12.\d.\d\+[0-9]{14}$/ }
+          let(:expected_version) { /^12.\d.\d/ }
 
           it_behaves_like "the right artifact list info"
         end
 
         context "with latest version keyword" do
           let(:product_version) { "latest" }
-          let(:expected_version) { /^\d\d.\d.\d\+[0-9]{14}$/ }
+          let(:expected_version) { /^\d\d.\d.\d/ }
 
           it_behaves_like "the right artifact list info"
         end
@@ -320,6 +322,7 @@ context "Mixlib::Install::Backend" do
 
     context "for unstable", :unstable do
       let(:channel) { :unstable }
+      let(:expected_protocol) { "http://" }
 
       context "when p, pv and m are not present" do
         context "with an integration product version" do
@@ -348,6 +351,14 @@ context "Mixlib::Install::Backend" do
 
             it_behaves_like "the right artifact info"
           end
+
+          context "with 'latest' product version" do
+            let(:product_version) { :latest }
+            let(:expected_info) { {} }
+            let(:expected_version) { /^\d\d.\d.\d\+[0-9]{14}$/ }
+
+            it_behaves_like "the right artifact info"
+          end
         end
 
         context "for windows" do
@@ -368,6 +379,14 @@ context "Mixlib::Install::Backend" do
           it "does not have storage/api in the url" do
             expect(info.url).not_to include("storage/api")
           end
+        end
+
+        context "for latest version"  do
+          let(:product_version) { :latest }
+          let(:expected_info) { {} }
+          let(:expected_version) { /^\d\d.\d.\d\+[0-9]{14}$/ }
+
+          it_behaves_like "the right artifact list info"
         end
       end
     end

--- a/spec/mixlib/install/generator_spec.rb
+++ b/spec/mixlib/install/generator_spec.rb
@@ -81,7 +81,7 @@ context "Mixlib::Install::Generator" do
           expect(install_script).to be_a(String)
           expect(install_script).to start_with("new-module -name Omnitruck -scriptblock")
           expect(install_script).to include("set-alias install -value Install-Project")
-          expect(install_script).to end_with("install -project #{options[:product_name]} -version #{options[:product_version]} -channel #{options[:channel]}\n")
+          expect(install_script).to match(/install -project #{options[:product_name]} -version .* -channel #{options[:channel]}\n/)
         end
       end
 

--- a/spec/mixlib/install/options_spec.rb
+++ b/spec/mixlib/install/options_spec.rb
@@ -44,15 +44,6 @@ context "Mixlib::Install::Options" do
     end
   end
 
-  context "for invalid product_version for unstable channel option" do
-    let(:channel) { :unstable }
-    let(:product_version) { "1.2.3" }
-
-    it "raises invalid version error" do
-      expect { Mixlib::Install.new(channel: channel, product_version: product_version) }.to raise_error(Mixlib::Install::Options::InvalidOptions, /Version must match pattern/)
-    end
-  end
-
   context "for platform options" do
     let(:channel) { :stable }
     let(:product_name) { "chef" }


### PR DESCRIPTION
Adds support for using `:latest` (code), or `'latest'` (kitchen.yml) when using the unstable channel against artifactory.

@jtimberman @sersut @schisamo 