### PR TITLE
Improved unstable channel error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ export ARTIFACTORY_PASSWORD='password'
 ```
 
 ### Unstable channel specs
-Some spec examples are tagged `:unstable` and can only run when connected to Chef's internal network.  These are excluded by default.  To run the `:unstable` tests run: `bundle exec rspec --tag unstable`.
+Some spec examples are tagged `:unstable` and can only run when connected to Chef's internal network.  These are excluded by default.  To run the `:unstable` tests run: `rake unstable`.
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,11 @@ end
 desc "Run all tests"
 task test: [:rubocop, :spec]
 
+desc "Run unstable channel tests"
+task "unstable" do
+  system("bundle exec rspec -t unstable")
+end
+
 desc "Render product matrix documentation"
 task "matrix" do
   require "mixlib/install/product"

--- a/lib/mixlib/install/backend/omnitruck.rb
+++ b/lib/mixlib/install/backend/omnitruck.rb
@@ -24,7 +24,7 @@ module Mixlib
   class Install
     class Backend
       class Omnitruck
-        OMNITRUCK_ENDPOINT = "https://omnitruck.chef.io/"
+        ENDPOINT = "https://omnitruck.chef.io/".freeze
 
         attr_accessor :options
 
@@ -55,7 +55,7 @@ module Mixlib
         private
 
         def omnitruck_get(resource, parameters)
-          uri = URI.parse(OMNITRUCK_ENDPOINT)
+          uri = URI.parse(ENDPOINT)
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = (uri.scheme == "https")
 

--- a/lib/mixlib/install/generator/base.rb
+++ b/lib/mixlib/install/generator/base.rb
@@ -47,7 +47,7 @@ module Mixlib
           # and returnt the contents of the script
           if File.exist? "#{script_path}.erb"
             # Default values to use incase they are not set in the context
-            context[:base_url] ||= Mixlib::Install::Backend::Omnitruck::OMNITRUCK_ENDPOINT
+            context[:base_url] ||= Mixlib::Install::Backend::Omnitruck::ENDPOINT
 
             context_object = OpenStruct.new(context).instance_eval { binding }
             ERB.new(File.read("#{script_path}.erb")).result(context_object)

--- a/spec/mixlib/install/artifactory_spec.rb
+++ b/spec/mixlib/install/artifactory_spec.rb
@@ -1,0 +1,62 @@
+#
+# Copyright:: Copyright (c) 2015 Chef, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+context "Mixlib::Install::Backend::Artifactory", :unstable do
+  let(:opts) {
+    {
+      channel: :unstable,
+      product_name: "chef",
+      product_version: :latest
+    }
+  }
+  let(:options) { Mixlib::Install::Options.new(opts) }
+  let(:artifactory) { Mixlib::Install::Backend::Artifactory.new(options) }
+
+  context "when setting invalid endpoint" do
+    it "raises a ConnectionError" do
+      wrap_env("ARTIFACTORY_ENDPOINT" => "http://artifactory.example.com") do
+        expect { artifactory.artifactory_info }.to raise_error Mixlib::Install::Backend::Artifactory::ConnectionError
+      end
+    end
+  end
+
+  context "when setting endpoint with trailing /" do
+    it "it allows the training slash" do
+      wrap_env("ARTIFACTORY_ENDPOINT" => "http://artifactory.chef.co/") do
+        artifactory.artifactory_info
+      end
+    end
+  end
+
+  context "when not setting endpoint" do
+    it "it uses the default" do
+      wrap_env("ARTIFACTORY_ENDPOINT" => nil) do
+        artifactory.artifactory_info
+      end
+    end
+  end
+
+  context "when using bad credentials" do
+    it "raises an AuthenticationError" do
+      wrap_env("ARTIFACTORY_USERNAME" => "nobodyherebythatname", "ARTIFACTORY_PASSWORD" => "secret") do
+        expect { artifactory.artifactory_info }.to raise_error Mixlib::Install::Backend::Artifactory::AuthenticationError
+      end
+    end
+  end
+end

--- a/spec/mixlib/install/options_spec.rb
+++ b/spec/mixlib/install/options_spec.rb
@@ -45,7 +45,6 @@ context "Mixlib::Install::Options" do
   end
 
   context "for platform options" do
-    let(:channel) { :stable }
     let(:product_name) { "chef" }
     let(:product_version) { "1.2.3" }
     let(:base_options) {
@@ -63,36 +62,50 @@ context "Mixlib::Install::Options" do
       end
     end
 
-    context "without platform version" do
-      let(:options) { base_options.merge(platform: platform, architecture: "1") }
+    context "for stable channel" do
+      let(:channel) { :stable }
 
-      it_behaves_like "invalid platform options"
-    end
+      context "without platform version" do
+        let(:options) { base_options.merge(platform: platform, architecture: "1") }
 
-    context "without architecture" do
-      let(:options) { base_options.merge(platform: platform, platform_version: "1") }
+        it_behaves_like "invalid platform options"
+      end
 
-      it_behaves_like "invalid platform options"
-    end
+      context "without architecture" do
+        let(:options) { base_options.merge(platform: platform, platform_version: "1") }
 
-    context "without platform" do
-      let(:options) { base_options.merge(architecture: "1", platform_version: "1") }
+        it_behaves_like "invalid platform options"
+      end
 
-      it_behaves_like "invalid platform options"
-    end
+      context "without platform" do
+        let(:options) { base_options.merge(architecture: "1", platform_version: "1") }
 
-    context "without any platform info" do
-      it "does not raise an error" do
-        expect { Mixlib::Install.new(base_options) }.to_not raise_error
+        it_behaves_like "invalid platform options"
+      end
+
+      context "without any platform info" do
+        it "does not raise an error" do
+          expect { Mixlib::Install.new(base_options) }.to_not raise_error
+        end
       end
     end
-  end
 
-  context "for shell type options" do
-    let(:shell_type) { :foo }
+    context "for unstable channel", :unstable do
+      let(:channel) { :unstable }
 
-    it "raises invalid shell type error" do
-      expect { Mixlib::Install.new(shell_type: shell_type) }.to raise_error(Mixlib::Install::Options::InvalidOptions, /Unknown shell type/)
+      it "raises invalid artifactory env vars error" do
+        wrap_env("ARTIFACTORY_USERNAME" => nil, "ARTIFACTORY_PASSWORD" => nil) do
+          expect { Mixlib::Install.new(base_options) }.to raise_error(Mixlib::Install::Options::ArtifactoryCredentialsNotFound)
+        end
+      end
+    end
+
+    context "for shell type options" do
+      let(:shell_type) { :foo }
+
+      it "raises invalid shell type error" do
+        expect { Mixlib::Install.new(shell_type: shell_type) }.to raise_error(Mixlib::Install::Options::InvalidOptions, /Unknown shell type/)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,3 +11,16 @@ RSpec.configure do |conf|
     c.syntax = :expect
   end
 end
+
+# Copied directly from
+# https://github.com/ScrappyAcademy/rock_candy/blob/master/lib/rock_candy/helpers.rb
+# Thank you, @cupakromer
+def wrap_env(envs = {})
+  original_envs = ENV.select { |k, _| envs.key? k }
+  envs.each { |k, v| ENV[k] = v }
+
+  yield
+ensure
+  envs.each { |k, _| ENV.delete k }
+  original_envs.each { |k, v| ENV[k] = v }
+end


### PR DESCRIPTION
… handling

1) case where required artifactory env vars are not set when using unstable channel
2) case where artifactory server can not be resolved
3) case where artifactory server returns 401 for bad credentials
4) case where user adds trailing slash to ENDPOINT

@sersut @schisamo first draft  going to refine more tomorrow and add the case where we get no results from querying artifactory or omnitruck