### PR TITLE
Add retry option to curl

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/helpers.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/helpers.sh
@@ -136,7 +136,7 @@ do_wget() {
 # do_curl URL FILENAME
 do_curl() {
   echo "trying curl..."
-  curl -sL -D $tmp_dir/stderr "$1" > "$2"
+  curl --retry 5 -sL -D $tmp_dir/stderr "$1" > "$2"
   rc=$?
   # check for 404
   grep "404 Not Found" $tmp_dir/stderr 2>&1 >/dev/null


### PR DESCRIPTION
wget retries 20 times by default, but curl does not retry at all. This should make the two methods have similar behavior.