### PR TITLE
Fix typo in URL for PowerShell examples.

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
@@ -5,7 +5,7 @@ function Get-ProjectMetadata {
     .DESCRIPTION
     Get metadata for project
     .EXAMPLE
-    iex (new-object net.webclient).downloadstring('https:/omnitruck.chef.io/install.ps1'); Get-ProjectMetadata -project chef -channel stable
+    iex (new-object net.webclient).downloadstring('https://omnitruck.chef.io/install.ps1'); Get-ProjectMetadata -project chef -channel stable
 
     Gets the download url, MD5 checksum, and SHA256 checksum for the latest stable release of Chef.
     .EXAMPLE

--- a/lib/mixlib/install/generator/powershell/scripts/get_project_metadata_for_artifactory.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/get_project_metadata_for_artifactory.ps1.erb
@@ -5,7 +5,7 @@ function Get-ProjectMetadata {
     .DESCRIPTION
     Get metadata for project
     .EXAMPLE
-    iex (new-object net.webclient).downloadstring('https:/omnitruck.chef.io/install.ps1'); Get-ProjectMetadata -project chef -channel stable
+    iex (new-object net.webclient).downloadstring('https://omnitruck.chef.io/install.ps1'); Get-ProjectMetadata -project chef -channel stable
 
     Gets the download url, MD5 checksum, and SHA256 checksum for the latest stable release of Chef.
     .EXAMPLE

--- a/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
@@ -5,7 +5,7 @@ function Install-Project {
     .DESCRIPTION
     Install a Chef Software, Inc. product
     .EXAMPLE
-    iex (new-object net.webclient).downloadstring('https:/omnitruck.chef.io/install.ps1'); Install-Project -project chef -channel stable
+    iex (new-object net.webclient).downloadstring('https://omnitruck.chef.io/install.ps1'); Install-Project -project chef -channel stable
 
     Installs the latest stable version of Chef.
     .EXAMPLE


### PR DESCRIPTION
There was a small copypasta typo which was just missing a forward slash from the example URL.