### PR TITLE
Skipping the lsb-release section on wrlinux

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -25,7 +25,7 @@
 machine=`uname -m`
 os=`uname -s`
 
-if test -f "/etc/lsb-release" && grep -q DISTRIB_ID /etc/lsb-release; then
+if test -f "/etc/lsb-release" && grep -q DISTRIB_ID /etc/lsb-release && ! grep -q wrlinux /etc/lsb-release; then
   platform=`grep DISTRIB_ID /etc/lsb-release | cut -d "=" -f 2 | tr '[A-Z]' '[a-z]'`
   platform_version=`grep DISTRIB_RELEASE /etc/lsb-release | cut -d "=" -f 2`
 elif test -f "/etc/debian_version"; then


### PR DESCRIPTION
Wind River Linux 7, used by Cisco for NX-OS and IOS-XR, has a
/etc/lsb-release file (unlike WRL5). However, the OS info we need
is actually in the os-release and cisco-release files. This change
skips reading the lsb-release file if it contains "wrlinux" so
the more appropriate OS info files can be read for this platform.

/cc @chef/engineering-services 