### PR TITLE
Fix Manage config file in product matrix

### DIFF
--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -220,7 +220,13 @@ PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
     ctl_command do |v|
       v < version_for("2.0.0") ? "opscode-manage-ctl" : "chef-manage-ctl"
     end
-    config_file "/etc/opscode-manage/manage.rb"
+    config_file do |v|
+      if v < version_for("2.0.0")
+        "/etc/opscode-manage/manage.rb"
+      else
+        "/etc/chef-manage/manage.rb"
+      end
+    end
   end
 
   product "private-chef" do

--- a/spec/mixlib/install/product_spec.rb
+++ b/spec/mixlib/install/product_spec.rb
@@ -101,6 +101,10 @@ context "PRODUCT_MATRIX" do
     PRODUCT_MATRIX.lookup(product_name, version).ctl_command
   end
 
+  let(:config_file) do
+    PRODUCT_MATRIX.lookup(product_name, version).config_file
+  end
+
   CHEF_PRODUCTS = ["chef", "chefdk", "chef-server", "manage", "chef-ha",
                    "reporting", "supermarket", "chef-marketplace", "chef-sync",
                    "delivery", "delivery-cli", "analytics", "compliance",
@@ -157,6 +161,10 @@ context "PRODUCT_MATRIX" do
       it "should return correct ctl_command" do
         expect(ctl_command).to eq("chef-manage-ctl")
       end
+
+      it "should return correct config_file" do
+        expect(config_file).to eq("/etc/chef-manage/manage.rb")
+      end
     end
 
     context "for latest" do
@@ -169,6 +177,10 @@ context "PRODUCT_MATRIX" do
       it "should return correct ctl_command" do
         expect(ctl_command).to eq("chef-manage-ctl")
       end
+
+      it "should return correct config_file" do
+        expect(config_file).to eq("/etc/chef-manage/manage.rb")
+      end
     end
 
     context "for < 2.0.0" do
@@ -180,6 +192,10 @@ context "PRODUCT_MATRIX" do
 
       it "should return correct ctl_command" do
         expect(ctl_command).to eq("opscode-manage-ctl")
+      end
+
+      it "should return correct config_file" do
+        expect(config_file).to eq("/etc/opscode-manage/manage.rb")
       end
     end
   end


### PR DESCRIPTION
This will resolve `ingredient_config` not managing the manage.rb config file.

```
* ingredient_config[manage] action render
  * directory[/etc/opscode-manage] action create (up to date)
  * file[/etc/opscode-manage/manage.rb] action create[2016-01-21T22:37:27+00:00] WARN: File /etc/opscode-manage/manage.rb managed by file[/etc/opscode-manage/manage.rb] is really a symlink. Managing the source file instead.
  [2016-01-21T22:37:27+00:00] WARN: Disable this warning by setting `manage_symlink_source true` on the resource
[2016-01-21T22:37:27+00:00] WARN: In a future Chef release, 'manage_symlink_source' will not be enabled by default
```