### PR TITLE
Use /builds endpoint to determine the latest version when using :unstable

### DIFF
--- a/lib/mixlib/install/generator/powershell.rb
+++ b/lib/mixlib/install/generator/powershell.rb
@@ -75,7 +75,7 @@ module Mixlib
 
         def product_version
           if options.for_artifactory?
-            options.resolved_version(artifacts)
+            artifacts.first.version
           else
             options.product_version
           end

--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -91,21 +91,6 @@ module Mixlib
         product_version.to_sym == :latest
       end
 
-      def resolved_version(artifacts)
-        if latest_version?
-          all_versions = artifacts.collect(&:version)
-          # params: list of all versions, no version filtering, no pre-releases, use build version
-          Mixlib::Versioning.find_target_version(
-            all_versions,
-            nil,
-            false,
-            true
-          ).to_s
-        else
-          product_version
-        end
-      end
-
       private
 
       def validate_product_names

--- a/spec/mixlib/install/artifactory_spec.rb
+++ b/spec/mixlib/install/artifactory_spec.rb
@@ -17,6 +17,9 @@
 
 require "spec_helper"
 
+require "mixlib/install/options"
+require "mixlib/install/backend/artifactory"
+
 context "Mixlib::Install::Backend::Artifactory", :unstable do
   let(:opts) {
     {
@@ -27,11 +30,12 @@ context "Mixlib::Install::Backend::Artifactory", :unstable do
   }
   let(:options) { Mixlib::Install::Options.new(opts) }
   let(:artifactory) { Mixlib::Install::Backend::Artifactory.new(options) }
+  let(:query) { "item.find({\"@omnibus.project\": \"chef\"})" }
 
   context "when setting invalid endpoint" do
     it "raises a ConnectionError" do
-      wrap_env("ARTIFACTORY_ENDPOINT" => "http://artifactory.example.com") do
-        expect { artifactory.artifactory_info }.to raise_error Mixlib::Install::Backend::Artifactory::ConnectionError
+      wrap_env("ARTIFACTORY_ENDPOINT" => "http://artifactory.example.com/") do
+        expect { artifactory.artifactory_query(query) }.to raise_error Mixlib::Install::Backend::Artifactory::ConnectionError
       end
     end
   end
@@ -39,7 +43,7 @@ context "Mixlib::Install::Backend::Artifactory", :unstable do
   context "when setting endpoint with trailing /" do
     it "it allows the training slash" do
       wrap_env("ARTIFACTORY_ENDPOINT" => "http://artifactory.chef.co/") do
-        artifactory.artifactory_info
+        artifactory.info
       end
     end
   end
@@ -47,7 +51,7 @@ context "Mixlib::Install::Backend::Artifactory", :unstable do
   context "when not setting endpoint" do
     it "it uses the default" do
       wrap_env("ARTIFACTORY_ENDPOINT" => nil) do
-        artifactory.artifactory_info
+        artifactory.info
       end
     end
   end
@@ -55,7 +59,7 @@ context "Mixlib::Install::Backend::Artifactory", :unstable do
   context "when using bad credentials" do
     it "raises an AuthenticationError" do
       wrap_env("ARTIFACTORY_USERNAME" => "nobodyherebythatname", "ARTIFACTORY_PASSWORD" => "secret") do
-        expect { artifactory.artifactory_info }.to raise_error Mixlib::Install::Backend::Artifactory::AuthenticationError
+        expect { artifactory.artifactory_query(query) }.to raise_error Mixlib::Install::Backend::Artifactory::AuthenticationError
       end
     end
   end


### PR DESCRIPTION
When we are running tests in CI, generally there are more than 1 parallel builds happening. When we do not use the build record we pick up the information about the latest build which most of the time is partial. Also when using `items.find()` in AQL artifactory returns a maximum of 1000 items and sometimes it doesn't include the artifacts we are looking for (We have a total of ~ 23k artifacts, way more items)

Still need to: 
- [x] Update specs for `:unstable` channel.

Sharing this for preview and incase there are any initial comments. 

/cc: @patrick-wright, @schisamo 