### PR TITLE
Give users a way to get 32 / 64 bit packages on Windows

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
@@ -66,7 +66,7 @@ function Get-ProjectMetadata {
   Write-Verbose "Platform Version: $platform_version"
 
   if ($architecture -eq 'auto') {
-    if (!($env:ProgramW6432 -eq $null) -And ($channel -eq 'current')) {
+    if (((get-wmiobject win32_operatingsystem).osarchitecture -like '64-bit') -and ($channel -like 'current')) {
       $architecture = 'x86_64'
     } else {
       $architecture = 'i386'

--- a/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
@@ -41,7 +41,10 @@ function Get-ProjectMetadata {
     [switch]
     $prerelease,
     [switch]
-    $nightlies
+    $nightlies,
+    [validateset('auto', 'i386', 'x86_64')]
+    [string]
+    $architecture = 'auto'
   )
 
   # The following legacy switches are just aliases for the current channel
@@ -62,21 +65,22 @@ function Get-ProjectMetadata {
   }
   Write-Verbose "Platform Version: $platform_version"
 
-  # TODO: When we ship a 64 bit ruby for Windows.
-  if (!($env:ProgramW6432 -eq $null) -And ($channel -eq 'current')) {
-    $machine = 'x86_64'
-  } else {
-    $machine = 'i386'
+  if ($architecture -eq 'auto') {
+    if (!($env:ProgramW6432 -eq $null) -And ($channel -eq 'current')) {
+      $architecture = 'x86_64'
+    } else {
+      $architecture = 'i386'
+    }
   }
 
-  Write-Verbose "Machine: $machine"
+  Write-Verbose "Architecture: $architecture"
   Write-Verbose "Project: $project"
 
   $metadata_base_url = "$($channel)/$($project)/metadata"
   $metadata_array = ("?v=$($version)",
     "p=$platform",
     "pv=$platform_version",
-    "m=$machine")
+    "m=$architecture")
   $metadata_base_url += [string]::join('&', $metadata_array)
   $metadata_url = new-uri $base_server_uri $metadata_base_url
 

--- a/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
@@ -63,7 +63,12 @@ function Get-ProjectMetadata {
   Write-Verbose "Platform Version: $platform_version"
 
   # TODO: When we ship a 64 bit ruby for Windows.
-  $machine = 'x86_64'
+  if (!($env:ProgramW6432 -eq $null) -And ($channel -eq 'current')) {
+    $machine = 'x86_64'
+  } else {
+    $machine = 'i386'
+  }
+
   Write-Verbose "Machine: $machine"
   Write-Verbose "Project: $project"
 

--- a/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
@@ -44,10 +44,13 @@ function Install-Project {
     [switch]
     $prerelease,
     [switch]
-    $nightlies
+    $nightlies,
+    [validateset('auto', 'i386', 'x86_64')]
+    [string]
+    $architecture = 'auto'
   )
 
-  $package_metadata = Get-ProjectMetadata -project $project -channel $channel -version $version -prerelease:$prerelease -nightlies:$nightlies
+  $package_metadata = Get-ProjectMetadata -project $project -channel $channel -version $version -prerelease:$prerelease -nightlies:$nightlies -architecture $architecture
 
   if (-not [string]::IsNullOrEmpty($filename)) {
     $download_directory = split-path $filename


### PR DESCRIPTION
I've added a switch that lets people force the architecture. If the switch is not specified, it will default to `auto`, which will give 64 bit packages on the current channel if the machine supports it.