### PR TITLE
Fix current specs by picking a version dynamically from omnitruck.

### DIFF
--- a/spec/mixlib/install/backend_spec.rb
+++ b/spec/mixlib/install/backend_spec.rb
@@ -42,6 +42,31 @@ context "Mixlib::Install::Backend" do
 
   let(:expected_protocol) { "https://" }
 
+  # We need full version number for some of our tests and
+  # for :current and :stable channels we auto-purge artifacts.
+  # So we query omnitruck here to find a version so that we can
+  # run our tests
+  def pick_version_for(channel)
+    Mixlib::Install.new(
+      channel: channel,
+      product_name: "chef",
+      product_version: :latest
+    ).artifact_info.first.version
+  end
+
+  def major_minor_patch_from(integration_version)
+    integration_version.split("+").first
+  end
+
+  def major_minor_from(integration_version)
+    v = major_minor_patch_from(integration_version).split(".")
+    "#{v[0]}.#{v[1]}"
+  end
+
+  def major_from(integration_version)
+    major_minor_patch_from(integration_version).split(".").first
+  end
+
   shared_examples_for "the right artifact info" do
     it "gives the right url artifact info" do
       if !expected_info.key?(:url)
@@ -219,19 +244,20 @@ context "Mixlib::Install::Backend" do
     context "for current" do
       let(:channel) { :current }
 
+      # call omnitruck and select a current version to run below tests.
+      let(:picked_current_version)  { pick_version_for(:current) }
+
       context "when p, pv and m are present" do
         let(:platform) { "mac_os_x" }
         let(:platform_version) { "10.9" }
         let(:architecture) { "x86_64" }
 
         context "with an integration product version" do
-          let(:product_version) { "12.4.3+20151006083011" }
+          let(:product_version) { picked_current_version }
           let(:expected_info) {
             {
-              url: "https://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12.4.3%2B20151006083011-1.dmg",
-              md5: "103f98e4b72407245bdf44a0357fd8e4",
-              sha256: "c74cac0ecdef969820770c6e21fcf249d623dba40ea9bacdb2de5cd3bfbeedaf",
-              version: "12.4.3+20151006083011"
+              url: "https://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/",
+              version: product_version
             }
           }
 
@@ -239,11 +265,11 @@ context "Mixlib::Install::Backend" do
         end
 
         context "with a major.minor.patch version" do
-          let(:product_version) { "12.4.3" }
+          let(:product_version) { major_minor_patch_from(picked_current_version) }
           let(:expected_info) {
             {
-              url: "https://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12.4.3%2B",
-              version: "12.4.3+"
+              url: "https://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/",
+              version: product_version
             }
           }
 
@@ -251,11 +277,12 @@ context "Mixlib::Install::Backend" do
         end
 
         context "with a major.minor product version" do
-          let(:product_version) { "12.4" }
+          let(:product_version) { major_minor_from(picked_current_version) }
+
           let(:expected_info) {
             {
-              url: "https://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12.4",
-              version: "12.4"
+              url: "https://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64",
+              version: product_version
             }
           }
 
@@ -263,11 +290,11 @@ context "Mixlib::Install::Backend" do
         end
 
         context "with a major product version" do
-          let(:product_version) { "12" }
+          let(:product_version) { major_from(picked_current_version) }
           let(:expected_info) {
             {
-              url: "https://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64/chef-12",
-              version: "12"
+              url: "https://opscode-omnibus-packages-current.s3.amazonaws.com/mac_os_x/10.9/x86_64",
+              version: product_version
             }
           }
 
@@ -284,36 +311,36 @@ context "Mixlib::Install::Backend" do
 
       context "when p, pv and m are not present" do
         context "with a full product version" do
-          let(:product_version) { "12.4.3+20151006083011" }
-          let(:expected_version) { "12.4.3+20151006083011" }
+          let(:product_version) { picked_current_version }
+          let(:expected_version) { picked_current_version }
 
           it_behaves_like "the right artifact list info"
         end
 
         context "with a major.minor.patch product version" do
-          let(:product_version) { "12.4.3" }
-          let(:expected_version) { /^12.4.3\+[0-9]{14}$/ }
+          let(:product_version) { major_minor_patch_from(picked_current_version) }
+          let(:expected_version) { /#{product_version}/ }
 
           it_behaves_like "the right artifact list info"
         end
 
         context "with a major.minor product version" do
-          let(:product_version) { "12.4" }
-          let(:expected_version) { /^12.4.\d/ }
+          let(:product_version) { major_minor_from(picked_current_version) }
+          let(:expected_version) { /#{product_version}/ }
 
           it_behaves_like "the right artifact list info"
         end
 
         context "with a major product version" do
-          let(:product_version) { "12" }
-          let(:expected_version) { /^12.\d.\d/ }
+          let(:product_version) { major_from(picked_current_version) }
+          let(:expected_version) { /#{product_version}/ }
 
           it_behaves_like "the right artifact list info"
         end
 
         context "with latest version keyword" do
           let(:product_version) { "latest" }
-          let(:expected_version) { /^\d\d.\d.\d/ }
+          let(:expected_version) { // }
 
           it_behaves_like "the right artifact list info"
         end


### PR DESCRIPTION
I think this is slightly better @jaym. Still not perfect but at least we are exercising the code path to call / parse `/versions` endpoint.

Replaces https://github.com/chef/mixlib-install/pull/55