### PR TITLE
Add extra linebreak as metadata might not have one at end

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/fetch_metadata.sh.erb
+++ b/lib/mixlib/install/generator/bourne/scripts/fetch_metadata.sh.erb
@@ -27,6 +27,7 @@ do_download "$metadata_url"  "$metadata_filename"
 
 cat "$metadata_filename"
 
+echo ""
 # check that all the mandatory fields in the downloaded metadata are there
 if grep '^url' $metadata_filename > /dev/null && grep '^sha256' $metadata_filename > /dev/null && grep '^md5' $metadata_filename > /dev/null; then
   echo "downloaded metadata file looks valid..."


### PR DESCRIPTION
This adds an extra linebreak for cosmetic reasons, as the metadata sometimes doesn't have one, and this screws up the rendering:

```
trying wget...
url	https://opscode-omnibus-packages.s3.amazonaws.com/mac_os_x/10.11/x86_64/chef-12.7.2-1.dmg
md5	b9583bb3a01fc23b31880df57b4c6111
sha256	66ffb6ab117bdb2f24cb5594c58815c7032a7a10b9e3221d34445192b15b07c5
version	12.7.2downloaded metadata file looks valid...
```