### PR TITLE
support single-platform artifact_info in #upgrade_available?

### DIFF
--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -37,8 +37,10 @@ module Mixlib
     #
     # Fetch artifact metadata information
     #
-    # @return [ArtifactInfo] fetched artifact data
-    #
+    # @return [Array<ArtifactInfo>] list of fetched artifact data for the configured
+    # channel, product name, and product version.
+    # @return [ArtifactInfo] fetched artifact data for the configured
+    # channel, product name, product version and platform info
     def artifact_info
       Backend.info(options)
     end
@@ -94,7 +96,9 @@ module Mixlib
     def upgrade_available?
       return true if current_version.nil?
 
-      available_ver = Mixlib::Versioning.parse(artifact_info.first.version)
+      artifact = artifact_info
+      artifact = artifact.first if artifact.is_a? Array
+      available_ver = Mixlib::Versioning.parse(artifact.version)
       current_ver = Mixlib::Versioning.parse(current_version)
       (available_ver > current_ver)
     end

--- a/spec/mixlib/install_spec.rb
+++ b/spec/mixlib/install_spec.rb
@@ -119,6 +119,26 @@ context "Mixlib::Install" do
         expect(installer.upgrade_available?).to eq(true)
       end
     end
+
+    context "with specific platform options" do
+      let(:product_name) { "chefdk" }
+      let(:platform) { "ubuntu" }
+      let(:platform_version) { "14.04" }
+      let(:architecture) { "x86_64" }
+      let(:current_version) { nil }
+
+      it "should report upgrade available" do
+        installer = Mixlib::Install.new(
+          product_name: product_name,
+          channel: channel,
+          product_version: product_version,
+          platform: platform,
+          platform_version: platform_version,
+          architecture: architecture
+        )
+        expect(installer.upgrade_available?).to eq(true)
+      end
+    end
   end
 
   context "install_sh" do


### PR DESCRIPTION
This PR allows `#upgrade_available?` to support the case where a single platform is targeted by the `Mixlib::Install` object (e.g., when `platform`, `platform_version`, and `architecture` options are provided to the initializer). Included spec test and updated `#artifact_info` documentation to reflect that the return value may be either `Array<ArtifactInfo>` or `ArtifactInfo`.
