### PR TITLE
Add chef-server-ha-provisioning package to the list

### DIFF
--- a/PRODUCT_MATRIX.md
+++ b/PRODUCT_MATRIX.md
@@ -8,6 +8,7 @@
 | Chef Server High Availability addon | chef-ha |
 | Chef Cloud Marketplace addon | chef-marketplace |
 | Chef Server | chef-server |
+| Chef Server HA Provisioning for AWS | chef-server-ha-provisioning |
 | Chef Server Replication addon | chef-sync |
 | Chef Development Kit | chefdk |
 | Chef Compliance | compliance |

--- a/lib/mixlib/install/artifact_info.rb
+++ b/lib/mixlib/install/artifact_info.rb
@@ -51,7 +51,7 @@ module Mixlib
               artifacts << ArtifactInfo.new(metadata.merge(
                 platform: p,
                 platform_version: pv,
-                architecture: m,
+                architecture: m
               ))
             end
           end

--- a/lib/mixlib/install/backend/artifactory.rb
+++ b/lib/mixlib/install/backend/artifactory.rb
@@ -94,7 +94,7 @@ Can not find any builds for #{options.product_name} in #{::Artifactory.endpoint}
           # it will run a high number of queries but it is fine because we
           # are using artifactory only for :unstable channel
           builds["buildsNumbers"].each do |build|
-            version = build["uri"].gsub("/", "")
+            version = build["uri"].delete("/")
             artifacts = artifactory_artifacts(version)
 
             return artifacts unless artifacts.empty?
@@ -148,7 +148,7 @@ items.find(
             platform:         artifact_map["omnibus.platform"],
             platform_version: artifact_map["omnibus.platform_version"],
             architecture:     artifact_map["omnibus.architecture"],
-            url:              artifact_map["downloadUri"],
+            url:              artifact_map["downloadUri"]
           )
         end
 
@@ -179,7 +179,7 @@ items.find(
           @client ||= ::Artifactory::Client.new(
             endpoint: endpoint,
             username: ENV["ARTIFACTORY_USERNAME"],
-            password: ENV["ARTIFACTORY_PASSWORD"],
+            password: ENV["ARTIFACTORY_PASSWORD"]
           )
         end
 

--- a/lib/mixlib/install/backend/omnitruck.rb
+++ b/lib/mixlib/install/backend/omnitruck.rb
@@ -44,7 +44,7 @@ module Mixlib
             ArtifactInfo.from_json(build,
                                    platform: options.platform,
                                    platform_version: options.platform_version,
-                                   architecture: options.architecture,
+                                   architecture: options.architecture
             )
           else
             builds = omnitruck_get("versions", v: options.product_version)

--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -53,7 +53,7 @@ module Mixlib
       def initialize(options)
         @options = options
         @defaults = {
-          shell_type: :sh
+          shell_type: :sh,
         }
 
         validate!

--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -198,6 +198,11 @@ PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
     config_file "/etc/opscode/chef-server.rb"
   end
 
+  product "chef-server-ha-provisioning" do
+    product_name "Chef Server HA Provisioning for AWS"
+    package_name "chef-server-ha-provisioning"
+  end
+
   product "chef-sync" do
     product_name "Chef Server Replication addon"
     package_name "chef-sync"

--- a/lib/mixlib/install/script_generator.rb
+++ b/lib/mixlib/install/script_generator.rb
@@ -166,7 +166,7 @@ module Mixlib
         fn = File.join(
           File.dirname(__FILE__),
           %w{.. .. .. support},
-          "install_command",
+          "install_command"
         )
         Util.shell_code_from_file(vars, fn, powershell,
                                   http_proxy: http_proxy, https_proxy: https_proxy)

--- a/spec/mixlib/install/backend_spec.rb
+++ b/spec/mixlib/install/backend_spec.rb
@@ -36,7 +36,7 @@ context "Mixlib::Install::Backend" do
       platform: platform,
       platform_version: platform_version,
       architecture: architecture,
-      shell_type: shell_type,
+      shell_type: shell_type
     ).artifact_info
   }
 
@@ -50,7 +50,7 @@ context "Mixlib::Install::Backend" do
     Mixlib::Install.new(
       channel: channel,
       product_name: "chef",
-      product_version: :latest,
+      product_version: :latest
     ).artifact_info.first.version
   end
 

--- a/spec/mixlib/install/backend_spec.rb
+++ b/spec/mixlib/install/backend_spec.rb
@@ -115,9 +115,9 @@ context "Mixlib::Install::Backend" do
 
   shared_examples_for "the right artifact list info" do
     it "has the correct number of platforms" do
-      # Currently we have 8 platforms in stable and 7 platforms in current.
+      # Currently we have 7 platforms in stable and 6 platforms in current.
       # We can add more in the future
-      expect(info.map(&:platform).uniq.length).to be >= 7
+      expect(info.map(&:platform).uniq.length).to be >= 6
 
       info.each do |artifact_info|
         expect(artifact_info).to be_a(Mixlib::Install::ArtifactInfo)

--- a/spec/mixlib/install/generator_spec.rb
+++ b/spec/mixlib/install/generator_spec.rb
@@ -68,7 +68,7 @@ context "Mixlib::Install::Generator" do
     context "sh shell type" do
       let(:add_options) {
         {
-          shell_type: :sh
+          shell_type: :sh,
         }
       }
 
@@ -100,7 +100,7 @@ context "Mixlib::Install::Generator" do
       context "when shell_type is set" do
         let(:add_options) {
           {
-            shell_type: :ps1
+            shell_type: :ps1,
           }
         }
 

--- a/spec/mixlib/install_spec.rb
+++ b/spec/mixlib/install_spec.rb
@@ -23,7 +23,7 @@ context "Mixlib::Install" do
     Mixlib::Install.new(
       product_name: product_name,
       channel: channel,
-      product_version: product_version,
+      product_version: product_version
     )
   end
 


### PR DESCRIPTION
I noticed that `chef-server-ha-provisioning` was missing from the product matrix, and therefore not consumable by chef-ingredient.   This PR should fix that.

Note to reviewers:  There's two additional commits I added to this PR.  One to fix failing style checks and the second to fix a failing spec test.