### PR TITLE
detect platform info using api

### DIFF
--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -100,6 +100,44 @@ module Mixlib
     end
 
     #
+    # Automatically set the platform options
+    #
+    def detect_platform
+      options.set_platform_info(self.class.detect_platform)
+    end
+
+    #
+    # Returns a Hash containing the platform info options
+    #
+    def self.detect_platform
+      platform_info = if RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
+                        `#{self.detect_platform_ps1}`
+                      else
+                        `#{self.detect_platform_sh}`
+                      end
+
+      {
+        platform: platform_info[0],
+        platform_version: platform_info[1],
+        architecture: platform_info[2],
+      }
+    end
+
+    #
+    # Returns the platform_detection.sh script
+    #
+    def self.detect_platform_sh
+      Mixlib::Install::Generator::Bourne.detect_platform_sh
+    end
+
+    #
+    # Returns the platform_detection.ps1 script
+    #
+    def self.detect_platform_ps1
+      Mixlib::Install::Generator::PowerShell.detect_platform_ps1
+    end
+
+    #
     # Returns the install.sh script
     # Supported context parameters:
     # ------------------

--- a/lib/mixlib/install/generator/bourne.rb
+++ b/lib/mixlib/install/generator/bourne.rb
@@ -33,6 +33,10 @@ module Mixlib
           install_command.join("\n\n")
         end
 
+        def self.detect_platform_sh
+          get_script("platform_detection.sh")
+        end
+
         def self.script_base_path
           File.join(File.dirname(__FILE__), "bourne/scripts")
         end

--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -160,6 +160,8 @@ if test "x$platform" = "xsolaris2"; then
   export PATH
 fi
 
+echo "$platform $platform_version $machine"
+
 ############
 # end of platform_detection.sh
 ############

--- a/lib/mixlib/install/generator/powershell.rb
+++ b/lib/mixlib/install/generator/powershell.rb
@@ -32,6 +32,13 @@ module Mixlib
           install_command.join("\n\n")
         end
 
+        def self.detect_platform_ps1
+          detect_platform_command = []
+          detect_platform_command << get_script("helpers.ps1")
+          detect_platform_command << get_script("platform_detection.ps1")
+          detect_platform_command.join("\n\n")
+        end
+
         def self.script_base_path
           File.join(File.dirname(__FILE__), "powershell/scripts")
         end

--- a/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
@@ -55,16 +55,10 @@ function Get-ProjectMetadata {
   $platform = 'windows'
   Write-Verbose "Platform: $platform"
 
-  # TODO: No Win10 build endpoint yet
-  switch -regex ((get-wmiobject win32_operatingsystem).version) {
-    '10\.0\.\d+' {$platform_version = '2012r2'}
-    '6\.3\.\d+'  {$platform_version = '2012r2'}
-    '6\.2\.\d+'  {$platform_version = '2012'}
-    '6\.1\.\d+'  {$platform_version = '2008r2'}
-    '6\.0\.\d+'  {$platform_version = '2008'}
-  }
+  $platform_version = Get-PlatformVersion
   Write-Verbose "Platform Version: $platform_version"
 
+  # Custom architecture detection based on channel
   if ($architecture -eq 'auto') {
     if (((get-wmiobject win32_operatingsystem).osarchitecture -like '64-bit') -and ($channel -like 'current')) {
       $architecture = 'x86_64'

--- a/lib/mixlib/install/generator/powershell/scripts/get_project_metadata_for_artifactory.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/get_project_metadata_for_artifactory.ps1.erb
@@ -49,22 +49,11 @@ function Get-ProjectMetadata {
   $platform = 'windows'
   Write-Verbose "Platform: $platform"
 
-  # TODO: No Win10 build endpoint yet
-  switch -regex ((get-wmiobject win32_operatingsystem).version) {
-    '10\.0\.\d+' {$platform_version = '2012r2'}
-    '6\.3\.\d+'  {$platform_version = '2012r2'}
-    '6\.2\.\d+'  {$platform_version = '2012'}
-    '6\.1\.\d+'  {$platform_version = '2008r2'}
-    '6\.0\.\d+'  {$platform_version = '2008'}
-  }
+  $platform_version = Get-PlatformVersion
   Write-Verbose "Platform Version: $platform_version"
 
   if ($architecture -eq 'auto') {
-    if (((get-wmiobject win32_operatingsystem).osarchitecture -like '64-bit')) {
-      $architecture = 'x86_64'
-    } else {
-      $architecture = 'i386'
-    }
+    $architecture = Get-PlatformArchitecture
   }
 
   Write-Verbose "Architecture: $architecture"

--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1
@@ -1,3 +1,23 @@
+function Get-PlatformVersion {
+  switch -regex ((get-wmiobject win32_operatingsystem).version) {
+    '10\.0\.\d+' {$platform_version = '2012r2'}
+    '6\.3\.\d+'  {$platform_version = '2012r2'}
+    '6\.2\.\d+'  {$platform_version = '2012'}
+    '6\.1\.\d+'  {$platform_version = '2008r2'}
+    '6\.0\.\d+'  {$platform_version = '2008'}
+  }
+  return $platform_version
+}
+
+function Get-PlatformArchitecture {
+  if ((get-wmiobject win32_operatingsystem).osarchitecture -like '64-bit') {
+    $architecture = 'x86_64'
+  } else {
+    $architecture = 'i386'
+  }
+  return $architecture
+}
+
 function New-Uri {
   param ($baseuri, $newuri)
 

--- a/lib/mixlib/install/generator/powershell/scripts/platform_detection.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/platform_detection.ps1
@@ -1,0 +1,4 @@
+$platform_version = Get-PlatformVersion
+$architecture = Get-PlatformArchitecture
+
+Write-Host "windows $platform_version $architecture"

--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -99,6 +99,19 @@ module Mixlib
         product_version.to_sym == :latest
       end
 
+      #
+      # Set the platform info on the instance
+      # info [Hash]
+      #  Hash with keys :platform, :platform_version and :architecture
+      #
+      def set_platform_info(info)
+        options[:platform] = info[:platform]
+        options[:platform_version] = info[:platform_version]
+        options[:architecture] = info[:architecture]
+
+        validate_options!
+      end
+
       private
 
       def validate_product_names

--- a/spec/mixlib/install/options_spec.rb
+++ b/spec/mixlib/install/options_spec.rb
@@ -65,6 +65,13 @@ context "Mixlib::Install::Options" do
     context "for stable channel" do
       let(:channel) { :stable }
 
+      context "for setting missing platform options" do
+        it "raises InvalidOptions" do
+          installer = Mixlib::Install.new(base_options)
+          expect { installer.options.set_platform_info({ platform: "foo" }) }.to raise_error(Mixlib::Install::Options::InvalidOptions, /platform, platform version, and architecture/)
+        end
+      end
+
       context "without platform version" do
         let(:options) { base_options.merge(platform: platform, architecture: "1") }
 

--- a/spec/mixlib/install_spec.rb
+++ b/spec/mixlib/install_spec.rb
@@ -176,4 +176,43 @@ context "Mixlib::Install" do
     end
   end
 
+  context "self.detect_platform" do
+    let(:product_name) { "chef" }
+    let(:platform_info) { Mixlib::Install.detect_platform }
+
+    it "should return platform info" do
+      expect(platform_info.size).to eq 3
+      expect(installer.options.platform).to be_nil
+      expect(installer.options.platform_version).to be_nil
+      expect(installer.options.architecture).to be_nil
+    end
+  end
+
+  context "detect_platform" do
+    let(:product_name) { "chef" }
+
+    it "should set options" do
+      installer.detect_platform
+      expect(installer.options.platform).not_to be_nil
+      expect(installer.options.platform_version).not_to be_nil
+      expect(installer.options.architecture).not_to be_nil
+    end
+  end
+
+  context "detect_platform_sh" do
+    let(:script) { Mixlib::Install.detect_platform_sh }
+
+    it "should return platform_detection.sh" do
+      expect(script).to include('echo "$platform $platform_version $machine"')
+    end
+  end
+
+  context "detect_platform_ps1" do
+    let(:script) { Mixlib::Install.detect_platform_ps1 }
+
+    it "should return platform_detection.ps1" do
+      expect(script).to include('Write-Host "windows $platform_version $architecture"')
+    end
+  end
+
 end


### PR DESCRIPTION
Adds `self.detect_platform` method to `Mixlib::Install`.

Calling the method will run the platform_detection script and parse the output in order to return a Hash of platform info.

This allows chef-ingredient to merge platform properties to be passed to the Mixlib::Install initialization.