### PR TITLE
Add chef-compliance product support

### DIFF
--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -36,6 +36,7 @@ module Mixlib
         chef
         chefdk
         chef-server
+        chef-compliance
         delivery-cli
         omnibus-toolchain
         push-jobs-client

--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -215,7 +215,7 @@ PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
     package_name "chefdk"
   end
 
-  product "compliance" do
+  product "chef-compliance" do
     product_name "Chef Compliance"
     package_name "chef-compliance"
     ctl_command "chef-compliance-ctl"

--- a/spec/mixlib/install/product_spec.rb
+++ b/spec/mixlib/install/product_spec.rb
@@ -107,7 +107,7 @@ context "PRODUCT_MATRIX" do
 
   CHEF_PRODUCTS = ["chef", "chefdk", "chef-server", "manage", "chef-ha",
                    "reporting", "supermarket", "chef-marketplace", "chef-sync",
-                   "delivery", "delivery-cli", "analytics", "compliance",
+                   "delivery", "delivery-cli", "analytics", "chef-compliance",
                    "push-server", "push-client", "private-chef", "chef-backend",
                    "omnibus-toolchain", "angrychef", "angry-omnibus-toolchain"]
 


### PR DESCRIPTION
Added `chef-compliance` to SUPPORTED_PRODUCT_NAMES.
Had to change the name used by the `product` resource as Artifactory was 404ing with just `compliance`.

All these examples worked with the `pw/mixlib-install-source` branch of `chef-ingredient`:

```
chef_ingredient 'chef-compliance' do
  channel :current
  artifactory_username node['artifactory']['username']
  artifactory_password node['artifactory']['password']
  version :latest
  action [:install, :reconfigure]
end
```

```
chef_ingredient 'chef-compliance' do
  channel :unstable
  artifactory_username node['artifactory']['username']
  artifactory_password node['artifactory']['password']
  version :latest
  action [:install, :reconfigure]
end
```

```
chef_ingredient 'chef-compliance' do
  artifactory_username node['artifactory']['username']
  artifactory_password node['artifactory']['password']
  version :latest
  action [:install, :reconfigure]
end
```