### PR TITLE
allow architecture option to be passed to powershell installer

### DIFF
--- a/lib/mixlib/install/generator/powershell.rb
+++ b/lib/mixlib/install/generator/powershell.rb
@@ -89,11 +89,11 @@ module Mixlib
         end
 
         def render_command
-          <<EOS
-install -project #{options.product_name} \
--version #{product_version} \
--channel #{options.channel}
-EOS
+          cmd = "install -project #{options.product_name}"
+          cmd << " -version #{product_version}"
+          cmd << " -channel #{options.channel}"
+          cmd << " -architecture #{options.architecture}" if options.architecture
+          cmd << "\n"
         end
       end
     end

--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -70,7 +70,6 @@ module Mixlib
 
         errors << validate_product_names
         errors << validate_channels
-        errors << validate_platform_info
         errors << validate_shell_type
 
         unless errors.compact.empty?
@@ -129,16 +128,6 @@ Must be one of: #{SUPPORTED_PRODUCT_NAMES.join(", ")}
           <<-EOS
 Unknown channel #{channel}.
 Must be one of: #{ALL_SUPPORTED_CHANNELS.join(", ")}
-          EOS
-        end
-      end
-
-      def validate_platform_info
-        platform_opts = [platform, platform_version, architecture]
-        if (platform_opts.any?(&:nil?)) &&
-            (platform_opts.any? { |opt| !opt.nil? })
-          <<-EOS
-platform, platform version, and architecture are all required when specifying Platform options.
           EOS
         end
       end

--- a/spec/mixlib/install/generator_spec.rb
+++ b/spec/mixlib/install/generator_spec.rb
@@ -81,7 +81,6 @@ context "Mixlib::Install::Generator" do
           expect(install_script).to be_a(String)
           expect(install_script).to start_with("new-module -name Omnitruck -scriptblock")
           expect(install_script).to include("set-alias install -value Install-Project")
-          expect(install_script).to match(/install -project #{options[:product_name]} -version .* -channel #{options[:channel]}\n/)
         end
       end
 
@@ -95,6 +94,11 @@ context "Mixlib::Install::Generator" do
         }
 
         it_behaves_like "the correct ps1 script"
+
+        it "adds an architecture param" do
+          expect(install_script).to match(/install -project #{options[:product_name]} -version .* -channel #{options[:channel]} -architecture #{options[:architecture]}\n/)
+        end
+
       end
 
       context "when shell_type is set" do
@@ -105,6 +109,10 @@ context "Mixlib::Install::Generator" do
         }
 
         it_behaves_like "the correct ps1 script"
+
+        it "adds ommits the architecture param" do
+          expect(install_script).to match(/install -project #{options[:product_name]} -version .* -channel #{options[:channel]}\n/)
+        end
       end
     end
   end

--- a/spec/mixlib/install/options_spec.rb
+++ b/spec/mixlib/install/options_spec.rb
@@ -54,48 +54,6 @@ context "Mixlib::Install::Options" do
         product_version: product_version,
       }
     }
-    let(:options) {}
-
-    shared_examples_for "invalid platform options" do
-      it "raises InvalidOptions" do
-        expect { Mixlib::Install.new(options) }.to raise_error(Mixlib::Install::Options::InvalidOptions, /platform, platform version, and architecture/)
-      end
-    end
-
-    context "for stable channel" do
-      let(:channel) { :stable }
-
-      context "for setting missing platform options" do
-        it "raises InvalidOptions" do
-          installer = Mixlib::Install.new(base_options)
-          expect { installer.options.set_platform_info({ platform: "foo" }) }.to raise_error(Mixlib::Install::Options::InvalidOptions, /platform, platform version, and architecture/)
-        end
-      end
-
-      context "without platform version" do
-        let(:options) { base_options.merge(platform: platform, architecture: "1") }
-
-        it_behaves_like "invalid platform options"
-      end
-
-      context "without architecture" do
-        let(:options) { base_options.merge(platform: platform, platform_version: "1") }
-
-        it_behaves_like "invalid platform options"
-      end
-
-      context "without platform" do
-        let(:options) { base_options.merge(architecture: "1", platform_version: "1") }
-
-        it_behaves_like "invalid platform options"
-      end
-
-      context "without any platform info" do
-        it "does not raise an error" do
-          expect { Mixlib::Install.new(base_options) }.to_not raise_error
-        end
-      end
-    end
 
     context "for unstable channel", :unstable do
       let(:channel) { :unstable }


### PR DESCRIPTION
currently the powershell install command will, by default, set the architecture of the product to install based on the architecture of the installing node. Thats reasonable but the `render_command` method has no way of passing an architecture in to `Install-Product`. This adds that.

Note that it makes no sense to do this to the bourne shell script because it does not use a dynamic `architecture` variable.

One side effect of this change and where I may be making incorrect assumptions is that it removes the validation ensuring that `platform`, `platform_version`, and `architecture` are all passed together. This needs to be able to pass architecture without passing in the others and I did not see the value for changing it to remove architecture and thus removed it all together. So feel free to comment on why that should at least partially be put back.