### PR TITLE
Load the Bintray backend with `Mixlib::Install::Backend`

### DIFF
--- a/lib/mixlib/install/backend.rb
+++ b/lib/mixlib/install/backend.rb
@@ -18,6 +18,7 @@
 
 require "mixlib/install/backend/omnitruck"
 require "mixlib/install/backend/artifactory"
+require "mixlib/install/backend/bintray"
 
 module Mixlib
   class Install


### PR DESCRIPTION
This allows us to instantiate an instance of the Bintray backend after a simple `require 'mixlib/install'`.

/cc @sersut @patrick-wright 