### PR TITLE
add a blank version value for non specific versions on windows just like linux

### DIFF
--- a/lib/mixlib/install/script_generator.rb
+++ b/lib/mixlib/install/script_generator.rb
@@ -69,7 +69,7 @@ module Mixlib
                               sudo_command}
 
       def initialize(version, powershell = false, opts = {})
-        @version = version || "latest"
+        @version = (version || "latest").to_s.downcase
         @powershell = powershell
         @http_proxy = nil
         @https_proxy = nil
@@ -198,7 +198,7 @@ module Mixlib
 
         url = "#{base}#{endpoint}"
         url << "?p=windows&m=x86_64&pv=2008r2" # same package for all versions
-        url << "&v=#{CGI.escape(version.to_s.downcase)}"
+        url << "&v=#{CGI.escape(version)}" unless %w{latest true nightlies}.include?(version)
         url << "&prerelease=true" if prerelease
         url << "&nightlies=true" if nightlies
         url


### PR DESCRIPTION
this uses the same version url value as we use for linux [here](https://github.com/chef/mixlib-install/blob/master/lib/mixlib/install/script_generator.rb#L110).