### PR TITLE
Remove md5 and sha1 usage from install.sh.

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/artifactory_urls.sh.erb
+++ b/lib/mixlib/install/generator/bourne/scripts/artifactory_urls.sh.erb
@@ -12,7 +12,6 @@
 # Outputs:
 # $download_url:
 # $sha256:
-# $md5:
 ############
 
 <% artifacts.each do |artifact| %>
@@ -20,7 +19,6 @@
   mkdir -p $artifact_info_dir
   touch "$artifact_info_dir/artifact_info"
   echo "url <%= artifact.url%>" >> "$artifact_info_dir/artifact_info"
-  echo "md5 <%= artifact.md5%>" >> "$artifact_info_dir/artifact_info"
   echo "sha256 <%= artifact.sha256%>" >> "$artifact_info_dir/artifact_info"
 <% end %>
 
@@ -28,4 +26,3 @@ artifact_info_for_platform="$tmp_dir/artifact_info/$platform/$platform_version/$
 
 download_url=`awk '$1 == "url" { print $2 }' "$artifact_info_for_platform"`
 sha256=`awk '$1 == "sha256" { print $2 }' "$artifact_info_for_platform"`
-md5=`awk '$1 == "md5" { print $2 }' "$artifact_info_for_platform"`

--- a/lib/mixlib/install/generator/bourne/scripts/fetch_metadata.sh.erb
+++ b/lib/mixlib/install/generator/bourne/scripts/fetch_metadata.sh.erb
@@ -15,7 +15,6 @@
 # Outputs:
 # $download_url:
 # $sha256:
-# $md5:
 ############
 
 echo "Getting information for $project $channel $version for $platform..."
@@ -29,7 +28,7 @@ cat "$metadata_filename"
 
 echo ""
 # check that all the mandatory fields in the downloaded metadata are there
-if grep '^url' $metadata_filename > /dev/null && grep '^sha256' $metadata_filename > /dev/null && grep '^md5' $metadata_filename > /dev/null; then
+if grep '^url' $metadata_filename > /dev/null && grep '^sha256' $metadata_filename > /dev/null; then
   echo "downloaded metadata file looks valid..."
 else
   echo "downloaded metadata file is corrupted or an uncaught error was encountered in downloading the file..."
@@ -41,7 +40,6 @@ fi
 
 download_url=`awk '$1 == "url" { print $2 }' "$metadata_filename"`
 sha256=`awk '$1 == "sha256" { print $2 }' "$metadata_filename"`
-md5=`awk '$1 == "md5" { print $2 }' "$metadata_filename"`
 
 ############
 # end of fetch_metadata.sh

--- a/lib/mixlib/install/generator/bourne/scripts/fetch_package.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/fetch_package.sh
@@ -34,7 +34,7 @@ download_dir=`dirname $download_filename`
 cached_file_available="false"
 if test -f $download_filename; then
   echo "$download_filename already exists, verifiying checksum..."
-  if do_checksum "$download_filename" "$sha256" "$md5"; then
+  if do_checksum "$download_filename" "$sha256"; then
     echo "checksum compare succeeded, using existing file!"
     cached_file_available="true"
   else
@@ -45,7 +45,7 @@ fi
 # download if no local version of the file available
 if test "x$cached_file_available" != "xtrue"; then
   do_download "$download_url"  "$download_filename"
-  do_checksum "$download_filename" "$sha256" "$md5" || checksum_mismatch
+  do_checksum "$download_filename" "$sha256" || checksum_mismatch
 fi
 
 ############

--- a/lib/mixlib/install/generator/bourne/scripts/helpers.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/helpers.sh
@@ -214,17 +214,8 @@ do_checksum() {
     echo "Comparing checksum with shasum..."
     checksum=`shasum -a 256 $1 | awk '{ print $1 }'`
     return `test "x$checksum" = "x$2"`
-  elif exists md5sum; then
-    echo "Comparing checksum with md5sum..."
-    checksum=`md5sum $1 | awk '{ print $1 }'`
-    return `test "x$checksum" = "x$3"`
-  elif exists md5; then
-    echo "Comparing checksum with md5..."
-    # this is for md5 utility on MacOSX (OSX 10.6-10.10) and $4 is the correct field
-    checksum=`md5 $1 | awk '{ print $4 }'`
-    return `test "x$checksum" = "x$3"`
   else
-    echo "WARNING: could not find a valid checksum program, pre-install shasum, md5sum or md5 in your O/S image to get valdation..."
+    echo "WARNING: could not find a valid checksum program, pre-install shasum or sha256sum in your O/S image to get valdation..."
     return 0
   fi
 }

--- a/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
@@ -7,11 +7,11 @@ function Get-ProjectMetadata {
     .EXAMPLE
     iex (new-object net.webclient).downloadstring('https://omnitruck.chef.io/install.ps1'); Get-ProjectMetadata -project chef -channel stable
 
-    Gets the download url, MD5 checksum, and SHA256 checksum for the latest stable release of Chef.
+    Gets the download url and SHA256 checksum for the latest stable release of Chef.
     .EXAMPLE
     iex (irm 'https://omnitruck.chef.io/install.ps1'); Get-ProjectMetadata -project chefdk -channel stable -version 0.8.0
 
-    Gets the download url, MD5 checksum, and SHA256 checksum for ChefDK 0.8.0.
+    Gets the download url and SHA256 checksum for ChefDK 0.8.0.
   #>
   [cmdletbinding()]
   param (

--- a/lib/mixlib/install/generator/powershell/scripts/get_project_metadata_for_artifactory.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/get_project_metadata_for_artifactory.ps1.erb
@@ -7,11 +7,11 @@ function Get-ProjectMetadata {
     .EXAMPLE
     iex (new-object net.webclient).downloadstring('https://omnitruck.chef.io/install.ps1'); Get-ProjectMetadata -project chef -channel stable
 
-    Gets the download url, MD5 checksum, and SHA256 checksum for the latest stable release of Chef.
+    Gets the download url and SHA256 checksum for the latest stable release of Chef.
     .EXAMPLE
     iex (irm 'https://omnitruck.chef.io/install.ps1'); Get-ProjectMetadata -project chefdk -channel stable -version 0.8.0
 
-    Gets the download url, MD5 checksum, and SHA256 checksum for ChefDK 0.8.0.
+    Gets the download url, and SHA256 checksum for ChefDK 0.8.0.
   #>
   [cmdletbinding()]
   param (
@@ -64,7 +64,6 @@ function Get-ProjectMetadata {
     New-Item -ItemType directory -Path $artifact_info_dir -force
     New-Item -ItemType file "$($artifact_info_dir)/artifact_info" -force
     "url <%= artifact.url%>" | out-file "$artifact_info_dir/artifact_info"
-    "md5 <%= artifact.md5%>" | out-file "$artifact_info_dir/artifact_info" -Append
     "sha256 <%= artifact.sha256%>" | out-file "$artifact_info_dir/artifact_info" -Append
   <% end %>
 


### PR DESCRIPTION
This PR removes the usage of md5 and sha1 in `install.sh`. With the recent migration to bintray, we do not keep track of the md5 for our packages anymore. We had a conversation with @schisamo and @lamont-granquist in Slack and decided that removing sha1 and md5 is not going to lead to common breakages. 

We also wanted to add a new check using `openssl` to cover some of the historical platforms that does not have sha256 support. 

/cc: @chef/engineering-services 

