### PR TITLE
wait for msiexec to exit

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
@@ -86,6 +86,7 @@ function Install-Project {
     if (Test-ProjectPackage -Path $download_destination -Algorithm 'SHA256' -Hash $package_metadata.sha256) {
       Write-Host "Installing $project from $download_destination"
       $p = Start-Process -FilePath "msiexec" -ArgumentList "/qn /i $download_destination" -Passthru -Wait
+      $p.WaitForExit()
       if ($p.ExitCode -ne 0) {
         throw "msiexec was not successful. Received exit code $($p.ExitCode)"
       }

--- a/support/install_command.ps1
+++ b/support/install_command.ps1
@@ -44,6 +44,7 @@ Function Download-Chef($url, $md5, $dst) {
 Function Install-Chef($msi) {
   Log "Installing Chef Omnibus package $msi"
   $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi" -Passthru -Wait
+  $p.WaitForExit()
 
   if ($p.ExitCode -ne 0) { throw "msiexec was not successful. Received exit code $($p.ExitCode)" }
 


### PR DESCRIPTION
So you'd think that calling `start-process` with `-wait` would prevent the cmdlet returning until `msiexec` completes. In most cases it does. I have seen cases in the past where this is not the case. Oddly this works as expected on my vagrant boxes but I was investigating https://github.com/test-kitchen/kitchen-ec2/issues/241 and was able to consistently reproduce on an EC2 instance calling `start-process -wait` returns immediately and the returned `Process` instance has a blank `ExitCode`.

This forces it to block and fixed EC2. I don't know why EC2 behaves differently here but I do know I have seen this before and have had to use a similar method to work around the problem.