### PR TITLE
replace install_command.ps1 md5 with sha256

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/helpers.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/helpers.sh
@@ -210,10 +210,6 @@ do_checksum() {
     echo "Comparing checksum with sha256sum..."
     checksum=`sha256sum $1 | awk '{ print $1 }'`
     return `test "x$checksum" = "x$2"`
-  elif exists shasum; then
-    echo "Comparing checksum with shasum..."
-    checksum=`shasum -a 256 $1 | awk '{ print $1 }'`
-    return `test "x$checksum" = "x$2"`
   else
     echo "WARNING: could not find a valid checksum program, pre-install shasum or sha256sum in your O/S image to get valdation..."
     return 0

--- a/lib/mixlib/install/generator/bourne/scripts/helpers.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/helpers.sh
@@ -210,6 +210,10 @@ do_checksum() {
     echo "Comparing checksum with sha256sum..."
     checksum=`sha256sum $1 | awk '{ print $1 }'`
     return `test "x$checksum" = "x$2"`
+  elif exists shasum; then
+    echo "Comparing checksum with shasum..."
+    checksum=`shasum -a 256 $1 | awk '{ print $1 }'`
+    return `test "x$checksum" = "x$2"`
   else
     echo "WARNING: could not find a valid checksum program, pre-install shasum or sha256sum in your O/S image to get valdation..."
     return 0

--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1
@@ -60,18 +60,9 @@ function Test-ProjectPackage {
     function Get-FileHash ($Path, $Algorithm) {
       $Path = (resolve-path $path).providerpath
       $hash = @{Algorithm = $Algorithm; Path = $Path}
-      if ($Algorithm -like 'MD5') {
-        use ($c = New-Object -TypeName Security.Cryptography.MD5CryptoServiceProvider) {
-          use ($in = (gi $path).OpenRead()) {
-            $hash.Hash = ([BitConverter]::ToString($c.ComputeHash($in))).Replace("-", "").ToUpper()
-          }
-        }
-      }
-      elseif ($Algorithm -like 'SHA256') {
-        use ($c = New-Object -TypeName Security.Cryptography.SHA256CryptoServiceProvider) {
-          use ($in = (gi $path).OpenRead()) {
-            $hash.Hash = ([BitConverter]::ToString($c.ComputeHash($in))).Replace("-", "").ToUpper()
-          }
+      use ($c = New-Object -TypeName Security.Cryptography.SHA256CryptoServiceProvider) {
+        use ($in = (gi $path).OpenRead()) {
+          $hash.Hash = ([BitConverter]::ToString($c.ComputeHash($in))).Replace("-", "").ToUpper()
         }
       }
       new-object PSObject -Property $hash

--- a/lib/mixlib/install/version.rb
+++ b/lib/mixlib/install/version.rb
@@ -1,5 +1,5 @@
 module Mixlib
   class Install
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
install_command.ps1 still referenced md5 checks.  This caused issues when using the ScriptGenerator.

There was a reference in helpers.ps1 in the generator scripts what was being bypassed, but I just removed it altogether.

@sersut @schisamo @mwrock 