### PR TITLE
Use 32-bit artifacts for 64-bit on windows when we do not have native 64-bit packages available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Use 32 bit windows artifacts for 64-bit, when there is no 64-bit native artifact.
 
 ## [1.0.1] - 2016-03-31
 ### Fixed

--- a/lib/mixlib/install/artifact_info.rb
+++ b/lib/mixlib/install/artifact_info.rb
@@ -74,6 +74,10 @@ module Mixlib
           architecture: architecture,
         }
       end
+
+      def clone_with(data)
+        ArtifactInfo.new(self.to_hash.merge(data))
+      end
     end
   end
 end

--- a/spec/mixlib/install/backend/bintray_spec.rb
+++ b/spec/mixlib/install/backend/bintray_spec.rb
@@ -90,6 +90,34 @@ context "Mixlib::Install::Backend::Bintray" do
     end
   end
 
+  context "for a product without native 64-bit builds" do
+    let(:channel) { :stable }
+    let(:product_name) { "chefdk" }
+    let(:product_version) { :latest }
+    let(:platform) { "windows" }
+    let(:platform_version) { "2012r2" }
+    let(:architecture) { "x86_64" }
+
+    it "returns 32 bit package for 64 bit" do
+      expect(artifact_info).to be_a Mixlib::Install::ArtifactInfo
+      expect(artifact_info.url).to match("x86")
+    end
+  end
+
+  context "for a product with native 64-bit builds" do
+    let(:channel) { :current }
+    let(:product_name) { "chef" }
+    let(:product_version) { :latest }
+    let(:platform) { "windows" }
+    let(:platform_version) { "2012r2" }
+    let(:architecture) { "x86_64" }
+
+    it "returns 64 bit package for 64 bit" do
+      expect(artifact_info).to be_a Mixlib::Install::ArtifactInfo
+      expect(artifact_info.url).to match("x64")
+    end
+  end
+
   context "architecture extraction" do
     let(:channel) { :stable }
     let(:product_name) { "chef" }
@@ -133,5 +161,4 @@ context "Mixlib::Install::Backend::Bintray" do
       end
     end
   end
-
 end


### PR DESCRIPTION
/cc: @patrick-wright 

Without this change when architecture is `x86_64` mixlib-install can not find any packages for `chefdk` since all `chefdk` builds are published for 32 bit only.