### PR TITLE
Return chef.bintray.com based urls for freebsd 9 artifacts.

### DIFF
--- a/spec/mixlib/install/backend_spec.rb
+++ b/spec/mixlib/install/backend_spec.rb
@@ -45,7 +45,13 @@ context "Mixlib::Install::Backend", :vcr do
     if expected_info && !expected_info.key?(:url)
       expect(url).to match /#{expected_info[:url]}/
     else
-      expect(url).to match expected_protocol
+      if channel == :unstable
+        expect(url).to include("http://artifactory.chef.co")
+      elsif url.include?("freebsd/9")
+        expect(url).to include("http://chef.bintray.com")
+      else
+        expect(url).to include("https://packages.chef.io")
+      end
     end
   end
 


### PR DESCRIPTION
/cc: @chef/engineering-services 

* Fixes https://github.com/chef/mixlib-install/issues/91

Need to update mixlib-install in omnitruck to fix https://github.com/chef/omnitruck/issues/170 once this is merged.