### PR TITLE
use .net 2 compliant sha 256 class so we can install on windows 2k8r2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.0.4]
+### Fixed
+- use `SHA256Managed` instead of `SHA256CryptoServiceProvider` to be compatible with .Net 2.0 which is the default runtime on Windows 2008 R2
+
 ## [1.0.3]
 ### Changed
 - Artifactory credentials are no longer required.  A designated account has been hard-coded as default.

--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1
@@ -60,7 +60,7 @@ function Test-ProjectPackage {
     function Get-FileHash ($Path, $Algorithm) {
       $Path = (resolve-path $path).providerpath
       $hash = @{Algorithm = $Algorithm; Path = $Path}
-      use ($c = New-Object -TypeName Security.Cryptography.SHA256CryptoServiceProvider) {
+      use ($c = New-Object -TypeName Security.Cryptography.SHA256Managed) {
         use ($in = (gi $path).OpenRead()) {
           $hash.Hash = ([BitConverter]::ToString($c.ComputeHash($in))).Replace("-", "").ToUpper()
         }

--- a/lib/mixlib/install/version.rb
+++ b/lib/mixlib/install/version.rb
@@ -1,5 +1,5 @@
 module Mixlib
   class Install
-    VERSION = "1.0.3"
+    VERSION = "1.0.4"
   end
 end

--- a/support/install_command.ps1
+++ b/support/install_command.ps1
@@ -23,7 +23,7 @@ Function Get-ChefMetadata($url) {
 
 Function Get-SHA256($src) {
   Try {
-    $c = New-Object -TypeName System.Security.Cryptography.SHA256CryptoServiceProvider
+    $c = New-Object -TypeName System.Security.Cryptography.SHA256Managed
     $bytes = $c.ComputeHash(($in = (Get-Item $src).OpenRead()))
     return ([System.BitConverter]::ToString($bytes)).Replace("-", "").ToLower()
   } Finally { if (($c -ne $null) -and ($c.GetType().GetMethod("Dispose") -ne $null)) { $c.Dispose() }; if ($in -ne $null) { $in.Dispose() } }


### PR DESCRIPTION
Currently installing on Windows 2008 R2 because `SHA256CryptoServiceProvider` is only available in .net 3.5 and higher which is not the default runtime on Windows 2008 R2. We can use `SHA256Managed` which has a equivilent API but it is not FIPS 140-2 validated and will break if the node is running in fips mode. This should be fine since only chef-client needs FIPS compatibility.

