### PR TITLE
Add el-5 to the list of platforms we are returning compat download endpoints

### DIFF
--- a/lib/mixlib/install/backend/bintray.rb
+++ b/lib/mixlib/install/backend/bintray.rb
@@ -219,7 +219,7 @@ module Mixlib
           platform_info = parse_platform_info(artifact_map)
 
           base_url = case "#{platform_info[:platform]}-#{platform_info[:platform_version]}"
-                     when "freebsd-9"
+                     when "freebsd-9", "el-5"
                        COMPAT_DOWNLOAD_URL_ENDPOINT
                      else
                        DOWNLOAD_URL_ENDPOINT

--- a/spec/mixlib/install/backend_spec.rb
+++ b/spec/mixlib/install/backend_spec.rb
@@ -47,7 +47,7 @@ context "Mixlib::Install::Backend", :vcr do
     else
       if channel == :unstable
         expect(url).to include("http://artifactory.chef.co")
-      elsif url.include?("freebsd/9")
+      elsif url.include?("freebsd/9") || url.include?("el/5")
         expect(url).to include("http://chef.bintray.com")
       else
         expect(url).to include("https://packages.chef.io")


### PR DESCRIPTION
/cc: @chef/engineering-services @schisamo @patrick-wright @jeremiahsnapp 

See [this](https://chefio.slack.com/archives/eng-services-support/p1460137138001949) and [this](https://chefio.slack.com/archives/eng-services-support/p1460147334002013) for an example of this failing on RHEL/CentOS 5. 

This is the list of platforms we have:
```
aix-6.1
aix-7.1
debian-6
debian-7
debian-8
el-5
el-6
el-7
freebsd-10
freebsd-9
ios_xr-6
mac_os_x-10.10
mac_os_x-10.11
mac_os_x-10.9
nexus-7
solaris2-5.10
solaris2-5.11
ubuntu-10.04
ubuntu-12.04
ubuntu-14.04
windows-2008r2
windows-2012
windows-2012r2
```

I think this change will be sufficient. 

- [ ] Update omnitruck with new mixlib-install after merge.