### PR TITLE
Backwards compatibility option for platform_version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ artifact.platform # => "mac_os_x"
 artifact.platform_version # => "10.10"
 ```
 
+### Use an artifact released for an earlier version of the platform
+```ruby
+options = {
+  channel: :current,
+  product_name: 'chef',
+  product_version: :latest,
+  platform: 'ubuntu',
+  platform_version: '15.04',
+  architecture: 'x86_64',
+  platform_version_compatibility_mode: true
+}
+
+artifact = Mixlib::Install.new(options).artifact_info
+
+artifact.platform # => "ubuntu"
+artifact.platform_version # => "14.04"
+```
+
 ## Unstable channel
 The `:unstable` channel is currently only available when connected to Chef's internal network.
 

--- a/lib/mixlib/install/backend/artifactory.rb
+++ b/lib/mixlib/install/backend/artifactory.rb
@@ -42,25 +42,12 @@ module Mixlib
         #
         # @return [Array<ArtifactInfo>] list of artifacts for the configured
         # channel, product name, and product version.
-        # @return [ArtifactInfo] arifact info for the configured
-        # channel, product name, product version and platform info
-        #
-        def info
-          artifacts = if options.latest_version?
-                        artifactory_latest
-                      else
-                        artifactory_artifacts(options.product_version)
-                      end
-
-          if options.platform
-            artifacts.select! do |a|
-              a.platform == options.platform &&
-                a.platform_version == options.platform_version &&
-                a.architecture == options.architecture
-            end
+        def available_artifacts
+          if options.latest_version?
+            artifactory_latest
+          else
+            artifactory_artifacts(options.product_version)
           end
-
-          artifacts.length == 1 ? artifacts.first : artifacts
         end
 
         #

--- a/lib/mixlib/install/backend/base.rb
+++ b/lib/mixlib/install/backend/base.rb
@@ -26,13 +26,86 @@ module Mixlib
           @options = options
         end
 
-        def info
-          raise "Must implement info method that returns ArtifactInfo or Array<ArtifactInfo>"
+        #
+        # Returns the list of artifacts from the configured backend based on the
+        # configured product_name, product_version and channel.
+        #
+        # @abstract Subclasses should define this method.
+        #
+        # @return Array<ArtifactInfo>
+        #   List of ArtifactInfo objects for the available artifacts.
+        def available_artifacts
+          raise "Must implement available_artifacts method that returns Array<ArtifactInfo>"
         end
 
-        def endpoint
-          raise "Must implement endpoint method that returns endpoint String"
+        #
+        # See #filter_artifacts
+        def info
+          filter_artifacts(available_artifacts)
         end
+
+        #
+        # Returns true if platform filters are available, false otherwise.
+        #
+        # Note that we assume #set_platform_info method is used on the Options
+        # class to set the platform options.
+        #
+        # @return TrueClass, FalseClass
+        def platform_filters_available?
+          !options.platform.nil?
+        end
+
+        #
+        # Filters and returns the available artifacts based on the configured
+        # platform filtering options.
+        #
+        # @return ArtifactInfo, Array<ArtifactInfo>, []
+        #   If the result is a single artifact, this returns ArtifactInfo.
+        #   If the result is a list of artifacts, this returns Array<ArtifactInfo>.
+        #   If no suitable artifact is found, this returns [].
+        def filter_artifacts(artifacts)
+          return artifacts unless platform_filters_available?
+
+          # First filter the artifacts based on the platform and architecture
+          artifacts.select! do |a|
+            a.platform == options.platform && a.architecture == options.architecture
+          end
+
+          # Now we are going to filter based on platform_version.
+          # We will return the artifact with an exact match if available.
+          # Otherwise we will search for a compatible artifact and return it
+          # if the compat options is set.
+          closest_compatible_artifact = nil
+
+          artifacts.each do |a|
+            return a if a.platform_version == options.platform_version
+
+            # We skip the artifacts produced for windows since their platform
+            # version is always set to 2008r2 which breaks our `to_f` comparison.
+            next if a.platform == "windows"
+
+            # Calculate the closest compatible version.
+            # For an artifact to be compatible it needs to be smaller than the
+            # platform_version specified in options.
+            # To find the closest compatible one we keep a max of the compatible
+            # artifacts.
+            if closest_compatible_artifact.nil? ||
+                (a.platform_version.to_f > closest_compatible_artifact.platform_version.to_f &&
+                  a.platform_version.to_f < options.platform_version.to_f )
+              closest_compatible_artifact = a
+            end
+          end
+
+          # If the compat flag is set and if we have found a compatible artifact
+          # we are going to use it.
+          if options.platform_version_compatibility_mode && closest_compatible_artifact
+            return closest_compatible_artifact
+          end
+
+           # Otherwise, we return an empty array indicating we do not have any matching artifacts
+          return []
+        end
+
       end
     end
   end

--- a/lib/mixlib/install/backend/bintray.rb
+++ b/lib/mixlib/install/backend/bintray.rb
@@ -51,27 +51,6 @@ module Mixlib
           @endpoint ||= ENV.fetch("BINTRAY_ENDPOINT", ENDPOINT)
         end
 
-        # Create filtered list of artifacts
-        #
-        # @return [Array<ArtifactInfo>] list of artifacts for the configured
-        # channel, product name, and product version.
-        # @return [ArtifactInfo] arifact info for the configured
-        # channel, product name, product version and platform info
-        #
-        def info
-          artifacts = bintray_artifacts
-
-          if options.platform
-            artifacts.select! do |a|
-              a.platform == options.platform &&
-                a.platform_version == options.platform_version &&
-                a.architecture == options.architecture
-            end
-          end
-
-          artifacts.length == 1 ? artifacts.first : artifacts
-        end
-
         #
         # Makes a GET request to bintray for the given path.
         #
@@ -111,7 +90,7 @@ module Mixlib
         #
         # @return [Array<ArtifactInfo>] Array of info about found artifacts
         #
-        def bintray_artifacts
+        def available_artifacts
           version = options.latest_version? ? latest_version : options.product_version
           begin
             results = bintray_get("#{options.channel}/#{options.product_name}/versions/#{version}/files")

--- a/lib/mixlib/install/backend/omnitruck.rb
+++ b/lib/mixlib/install/backend/omnitruck.rb
@@ -31,7 +31,7 @@ module Mixlib
           @endpoint ||= ENV.fetch("OMNITRUCK_ENDPOINT", ENDPOINT)
         end
 
-        def info
+        def available_artifacts
           # If we are querying a single platform we need to call metadata
           # endpoint otherwise we need to call versions endpoint in omnitruck
           if options.platform

--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -39,6 +39,7 @@ module Mixlib
         :product_name,
         :product_version,
         :shell_type,
+        :platform_version_compatibility_mode,
       ]
 
       def initialize(options)
@@ -107,6 +108,7 @@ module Mixlib
       def default_options
         {
           shell_type: :sh,
+          platform_version_compatibility_mode: false,
         }
       end
 

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_Bintray/for_a_version_of_el_that_is_not_added_to_our_matrix/can_not_find_an_artifact.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_Bintray/for_a_version_of_el_that_is_not_added_to_our_matrix/can_not_find_an_artifact.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://mixlib-install%40chef:a83d3a2ffad50eb9a2230f281a2e19b70fe0db2d@bintray.com/api/v1/packages/chef/stable/delivery-cli/versions/_latest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 25 Apr 2016 22:15:13 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '0'
+      X-Ratelimit-Remaining:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=0
+    body:
+      encoding: UTF-8
+      string: '{"name":"0.0.6","desc":"","package":"delivery-cli","repo":"stable","owner":"chef","labels":[],"attribute_names":["project","version","iteration"],"created":"2016-04-21T22:02:27.725Z","updated":"2016-04-21T22:03:13.779Z","released":"","ordinal":19.0}'
+    http_version: 
+  recorded_at: Mon, 25 Apr 2016 22:15:13 GMT
+- request:
+    method: get
+    uri: https://mixlib-install%40chef:a83d3a2ffad50eb9a2230f281a2e19b70fe0db2d@bintray.com/api/v1/packages/chef/stable/delivery-cli/versions/0.0.6/files
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 25 Apr 2016 22:15:13 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '0'
+      X-Ratelimit-Remaining:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=0
+    body:
+      encoding: UTF-8
+      string: '[{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm","path":"el/6/delivery-cli-0.0.6-1.el6.x86_64.rpm","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:29.581Z","size":4713216,"sha1":"2cd3132e5821f4a1128c6c43170fa22f19828bb8","sha256":"6c58e42fe8fd36c3a8cdbc1cae9ae79734e12b8f3a0b542aa3fd6dc4ebd1ef95"},{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","path":"el/6/delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:32.600Z","size":183,"sha1":"1ab57bd4e4d93b6dcea928b2a269e195bd521a83","sha256":"15f398471abcff9198111a06fc6f83b64f8ee6c1c3f7127323330932abbb3754"},{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm","path":"el/7/delivery-cli-0.0.6-1.el6.x86_64.rpm","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:31.150Z","size":4713216,"sha1":"2cd3132e5821f4a1128c6c43170fa22f19828bb8","sha256":"6c58e42fe8fd36c3a8cdbc1cae9ae79734e12b8f3a0b542aa3fd6dc4ebd1ef95"},{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","path":"el/7/delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:03:02.721Z","size":183,"sha1":"e4421ce70716c9ada353e22e0f43d24e049a4345","sha256":"bfc74e2d998d7938ce47d39cbe51240fc471420d75746b50aaec26e6e571542d"},{"name":"delivery-cli_0.0.6-1_amd64.deb","path":"ubuntu/12.04/delivery-cli_0.0.6-1_amd64.deb","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:33.888Z","size":4712348,"sha1":"4515acfd827ef063409cf247ae61f33c84d3400b","sha256":"a9475b569fe432cbdb00149e4b6042efe92f8c65b1342cd61056688d938f39a8"},{"name":"delivery-cli_0.0.6-1_amd64.deb.asc","path":"ubuntu/12.04/delivery-cli_0.0.6-1_amd64.deb.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:03:04.599Z","size":183,"sha1":"0c88b425e169139155ffe5155f7d7306ea25f153","sha256":"ba4ce5d128a480892ea75fda105b64a24cf21f3872917889496c6ac1d3ce0db9"},{"name":"delivery-cli_0.0.6-1_amd64.deb","path":"ubuntu/14.04/delivery-cli_0.0.6-1_amd64.deb","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:32.072Z","size":4689006,"sha1":"5aed286dccb707276dae71577c7e149b604bd20d","sha256":"9db49787b4268fea62962d9339378c1af570db279e6c33d6e6327df330564e4f"},{"name":"delivery-cli_0.0.6-1_amd64.deb.asc","path":"ubuntu/14.04/delivery-cli_0.0.6-1_amd64.deb.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:35.369Z","size":183,"sha1":"a9f27f4de0e8bf021fd77a4d0764f4f24bc0aa64","sha256":"592353a22aced8041016449c3b123ef26a74e5241bbad8b055724ab424d31534"}]'
+    http_version: 
+  recorded_at: Mon, 25 Apr 2016 22:15:13 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_Bintray/for_a_version_of_el_that_is_not_added_to_our_matrix/when_product_version_compat_mode_is_set/finds_an_artifact.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_Bintray/for_a_version_of_el_that_is_not_added_to_our_matrix/when_product_version_compat_mode_is_set/finds_an_artifact.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://mixlib-install%40chef:a83d3a2ffad50eb9a2230f281a2e19b70fe0db2d@bintray.com/api/v1/packages/chef/stable/delivery-cli/versions/_latest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 25 Apr 2016 22:15:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '0'
+      X-Ratelimit-Remaining:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=0
+    body:
+      encoding: UTF-8
+      string: '{"name":"0.0.6","desc":"","package":"delivery-cli","repo":"stable","owner":"chef","labels":[],"attribute_names":["project","version","iteration"],"created":"2016-04-21T22:02:27.725Z","updated":"2016-04-21T22:03:13.779Z","released":"","ordinal":19.0}'
+    http_version: 
+  recorded_at: Mon, 25 Apr 2016 22:15:14 GMT
+- request:
+    method: get
+    uri: https://mixlib-install%40chef:a83d3a2ffad50eb9a2230f281a2e19b70fe0db2d@bintray.com/api/v1/packages/chef/stable/delivery-cli/versions/0.0.6/files
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 25 Apr 2016 22:15:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '0'
+      X-Ratelimit-Remaining:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=0
+    body:
+      encoding: UTF-8
+      string: '[{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm","path":"el/6/delivery-cli-0.0.6-1.el6.x86_64.rpm","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:29.581Z","size":4713216,"sha1":"2cd3132e5821f4a1128c6c43170fa22f19828bb8","sha256":"6c58e42fe8fd36c3a8cdbc1cae9ae79734e12b8f3a0b542aa3fd6dc4ebd1ef95"},{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","path":"el/6/delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:32.600Z","size":183,"sha1":"1ab57bd4e4d93b6dcea928b2a269e195bd521a83","sha256":"15f398471abcff9198111a06fc6f83b64f8ee6c1c3f7127323330932abbb3754"},{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm","path":"el/7/delivery-cli-0.0.6-1.el6.x86_64.rpm","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:31.150Z","size":4713216,"sha1":"2cd3132e5821f4a1128c6c43170fa22f19828bb8","sha256":"6c58e42fe8fd36c3a8cdbc1cae9ae79734e12b8f3a0b542aa3fd6dc4ebd1ef95"},{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","path":"el/7/delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:03:02.721Z","size":183,"sha1":"e4421ce70716c9ada353e22e0f43d24e049a4345","sha256":"bfc74e2d998d7938ce47d39cbe51240fc471420d75746b50aaec26e6e571542d"},{"name":"delivery-cli_0.0.6-1_amd64.deb","path":"ubuntu/12.04/delivery-cli_0.0.6-1_amd64.deb","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:33.888Z","size":4712348,"sha1":"4515acfd827ef063409cf247ae61f33c84d3400b","sha256":"a9475b569fe432cbdb00149e4b6042efe92f8c65b1342cd61056688d938f39a8"},{"name":"delivery-cli_0.0.6-1_amd64.deb.asc","path":"ubuntu/12.04/delivery-cli_0.0.6-1_amd64.deb.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:03:04.599Z","size":183,"sha1":"0c88b425e169139155ffe5155f7d7306ea25f153","sha256":"ba4ce5d128a480892ea75fda105b64a24cf21f3872917889496c6ac1d3ce0db9"},{"name":"delivery-cli_0.0.6-1_amd64.deb","path":"ubuntu/14.04/delivery-cli_0.0.6-1_amd64.deb","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:32.072Z","size":4689006,"sha1":"5aed286dccb707276dae71577c7e149b604bd20d","sha256":"9db49787b4268fea62962d9339378c1af570db279e6c33d6e6327df330564e4f"},{"name":"delivery-cli_0.0.6-1_amd64.deb.asc","path":"ubuntu/14.04/delivery-cli_0.0.6-1_amd64.deb.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:35.369Z","size":183,"sha1":"a9f27f4de0e8bf021fd77a4d0764f4f24bc0aa64","sha256":"592353a22aced8041016449c3b123ef26a74e5241bbad8b055724ab424d31534"}]'
+    http_version: 
+  recorded_at: Mon, 25 Apr 2016 22:15:14 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_Bintray/for_a_version_of_ubuntu_that_is_not_added_to_our_matrix/can_not_find_an_artifact.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_Bintray/for_a_version_of_ubuntu_that_is_not_added_to_our_matrix/can_not_find_an_artifact.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://mixlib-install%40chef:a83d3a2ffad50eb9a2230f281a2e19b70fe0db2d@bintray.com/api/v1/packages/chef/stable/delivery-cli/versions/_latest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 25 Apr 2016 22:14:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '0'
+      X-Ratelimit-Remaining:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=0
+    body:
+      encoding: UTF-8
+      string: '{"name":"0.0.6","desc":"","package":"delivery-cli","repo":"stable","owner":"chef","labels":[],"attribute_names":["project","version","iteration"],"created":"2016-04-21T22:02:27.725Z","updated":"2016-04-21T22:03:13.779Z","released":"","ordinal":19.0}'
+    http_version: 
+  recorded_at: Mon, 25 Apr 2016 22:14:01 GMT
+- request:
+    method: get
+    uri: https://mixlib-install%40chef:a83d3a2ffad50eb9a2230f281a2e19b70fe0db2d@bintray.com/api/v1/packages/chef/stable/delivery-cli/versions/0.0.6/files
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 25 Apr 2016 22:14:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '0'
+      X-Ratelimit-Remaining:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=0
+    body:
+      encoding: UTF-8
+      string: '[{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm","path":"el/6/delivery-cli-0.0.6-1.el6.x86_64.rpm","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:29.581Z","size":4713216,"sha1":"2cd3132e5821f4a1128c6c43170fa22f19828bb8","sha256":"6c58e42fe8fd36c3a8cdbc1cae9ae79734e12b8f3a0b542aa3fd6dc4ebd1ef95"},{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","path":"el/6/delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:32.600Z","size":183,"sha1":"1ab57bd4e4d93b6dcea928b2a269e195bd521a83","sha256":"15f398471abcff9198111a06fc6f83b64f8ee6c1c3f7127323330932abbb3754"},{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm","path":"el/7/delivery-cli-0.0.6-1.el6.x86_64.rpm","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:31.150Z","size":4713216,"sha1":"2cd3132e5821f4a1128c6c43170fa22f19828bb8","sha256":"6c58e42fe8fd36c3a8cdbc1cae9ae79734e12b8f3a0b542aa3fd6dc4ebd1ef95"},{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","path":"el/7/delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:03:02.721Z","size":183,"sha1":"e4421ce70716c9ada353e22e0f43d24e049a4345","sha256":"bfc74e2d998d7938ce47d39cbe51240fc471420d75746b50aaec26e6e571542d"},{"name":"delivery-cli_0.0.6-1_amd64.deb","path":"ubuntu/12.04/delivery-cli_0.0.6-1_amd64.deb","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:33.888Z","size":4712348,"sha1":"4515acfd827ef063409cf247ae61f33c84d3400b","sha256":"a9475b569fe432cbdb00149e4b6042efe92f8c65b1342cd61056688d938f39a8"},{"name":"delivery-cli_0.0.6-1_amd64.deb.asc","path":"ubuntu/12.04/delivery-cli_0.0.6-1_amd64.deb.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:03:04.599Z","size":183,"sha1":"0c88b425e169139155ffe5155f7d7306ea25f153","sha256":"ba4ce5d128a480892ea75fda105b64a24cf21f3872917889496c6ac1d3ce0db9"},{"name":"delivery-cli_0.0.6-1_amd64.deb","path":"ubuntu/14.04/delivery-cli_0.0.6-1_amd64.deb","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:32.072Z","size":4689006,"sha1":"5aed286dccb707276dae71577c7e149b604bd20d","sha256":"9db49787b4268fea62962d9339378c1af570db279e6c33d6e6327df330564e4f"},{"name":"delivery-cli_0.0.6-1_amd64.deb.asc","path":"ubuntu/14.04/delivery-cli_0.0.6-1_amd64.deb.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:35.369Z","size":183,"sha1":"a9f27f4de0e8bf021fd77a4d0764f4f24bc0aa64","sha256":"592353a22aced8041016449c3b123ef26a74e5241bbad8b055724ab424d31534"}]'
+    http_version: 
+  recorded_at: Mon, 25 Apr 2016 22:14:02 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_Bintray/for_a_version_of_ubuntu_that_is_not_added_to_our_matrix/when_product_version_compat_mode_is_set/finds_an_artifact.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_Bintray/for_a_version_of_ubuntu_that_is_not_added_to_our_matrix/when_product_version_compat_mode_is_set/finds_an_artifact.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://mixlib-install%40chef:a83d3a2ffad50eb9a2230f281a2e19b70fe0db2d@bintray.com/api/v1/packages/chef/stable/delivery-cli/versions/_latest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 25 Apr 2016 22:14:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '0'
+      X-Ratelimit-Remaining:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=0
+    body:
+      encoding: UTF-8
+      string: '{"name":"0.0.6","desc":"","package":"delivery-cli","repo":"stable","owner":"chef","labels":[],"attribute_names":["project","version","iteration"],"created":"2016-04-21T22:02:27.725Z","updated":"2016-04-21T22:03:13.779Z","released":"","ordinal":19.0}'
+    http_version: 
+  recorded_at: Mon, 25 Apr 2016 22:14:02 GMT
+- request:
+    method: get
+    uri: https://mixlib-install%40chef:a83d3a2ffad50eb9a2230f281a2e19b70fe0db2d@bintray.com/api/v1/packages/chef/stable/delivery-cli/versions/0.0.6/files
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 25 Apr 2016 22:14:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '0'
+      X-Ratelimit-Remaining:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=0
+    body:
+      encoding: UTF-8
+      string: '[{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm","path":"el/6/delivery-cli-0.0.6-1.el6.x86_64.rpm","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:29.581Z","size":4713216,"sha1":"2cd3132e5821f4a1128c6c43170fa22f19828bb8","sha256":"6c58e42fe8fd36c3a8cdbc1cae9ae79734e12b8f3a0b542aa3fd6dc4ebd1ef95"},{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","path":"el/6/delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:32.600Z","size":183,"sha1":"1ab57bd4e4d93b6dcea928b2a269e195bd521a83","sha256":"15f398471abcff9198111a06fc6f83b64f8ee6c1c3f7127323330932abbb3754"},{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm","path":"el/7/delivery-cli-0.0.6-1.el6.x86_64.rpm","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:31.150Z","size":4713216,"sha1":"2cd3132e5821f4a1128c6c43170fa22f19828bb8","sha256":"6c58e42fe8fd36c3a8cdbc1cae9ae79734e12b8f3a0b542aa3fd6dc4ebd1ef95"},{"name":"delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","path":"el/7/delivery-cli-0.0.6-1.el6.x86_64.rpm.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:03:02.721Z","size":183,"sha1":"e4421ce70716c9ada353e22e0f43d24e049a4345","sha256":"bfc74e2d998d7938ce47d39cbe51240fc471420d75746b50aaec26e6e571542d"},{"name":"delivery-cli_0.0.6-1_amd64.deb","path":"ubuntu/12.04/delivery-cli_0.0.6-1_amd64.deb","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:33.888Z","size":4712348,"sha1":"4515acfd827ef063409cf247ae61f33c84d3400b","sha256":"a9475b569fe432cbdb00149e4b6042efe92f8c65b1342cd61056688d938f39a8"},{"name":"delivery-cli_0.0.6-1_amd64.deb.asc","path":"ubuntu/12.04/delivery-cli_0.0.6-1_amd64.deb.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:03:04.599Z","size":183,"sha1":"0c88b425e169139155ffe5155f7d7306ea25f153","sha256":"ba4ce5d128a480892ea75fda105b64a24cf21f3872917889496c6ac1d3ce0db9"},{"name":"delivery-cli_0.0.6-1_amd64.deb","path":"ubuntu/14.04/delivery-cli_0.0.6-1_amd64.deb","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:32.072Z","size":4689006,"sha1":"5aed286dccb707276dae71577c7e149b604bd20d","sha256":"9db49787b4268fea62962d9339378c1af570db279e6c33d6e6327df330564e4f"},{"name":"delivery-cli_0.0.6-1_amd64.deb.asc","path":"ubuntu/14.04/delivery-cli_0.0.6-1_amd64.deb.asc","repo":"stable","package":"delivery-cli","version":"0.0.6","owner":"chef","created":"2016-04-21T22:02:35.369Z","size":183,"sha1":"a9f27f4de0e8bf021fd77a4d0764f4f24bc0aa64","sha256":"592353a22aced8041016449c3b123ef26a74e5241bbad8b055724ab424d31534"}]'
+    http_version: 
+  recorded_at: Mon, 25 Apr 2016 22:14:02 GMT
+recorded_with: VCR 3.0.1

--- a/spec/mixlib/install/backend/bintray_spec.rb
+++ b/spec/mixlib/install/backend/bintray_spec.rb
@@ -27,12 +27,14 @@ context "Mixlib::Install::Backend::Bintray", :vcr do
   let(:platform) { nil }
   let(:platform_version) { nil }
   let(:architecture) { nil }
+  let(:pv_compat) { nil }
 
   let(:options) do
     {}.tap do |opt|
       opt[:product_name] = product_name
       opt[:product_version] = product_version
       opt[:channel] = channel
+      opt[:platform_version_compatibility_mode] = pv_compat if pv_compat
       if platform
         opt[:platform] = platform
         opt[:platform_version] = platform_version
@@ -159,6 +161,54 @@ context "Mixlib::Install::Backend::Bintray", :vcr do
       expect(artifact_info.platform).to eq "solaris2"
       expect(artifact_info.platform_version).to eq "5.10"
       expect(artifact_info.architecture).to eq "sparc"
+    end
+  end
+
+  context "for a version of ubuntu that is not added to our matrix" do
+    let(:channel) { :stable }
+    let(:product_name) { "delivery-cli" }
+    let(:product_version) { :latest }
+    let(:platform) { "ubuntu" }
+    let(:platform_version) { "15.04" }
+    let(:architecture) { "x86_64" }
+
+    it "can not find an artifact" do
+      expect(artifact_info).to be_empty
+    end
+
+    context "when product_version compat mode is set" do
+      let(:pv_compat) { true }
+
+      it "finds an artifact" do
+        expect(artifact_info).to be_a Mixlib::Install::ArtifactInfo
+        expect(artifact_info.platform).to eq "ubuntu"
+        expect(artifact_info.platform_version).to eq "14.04"
+        expect(artifact_info.architecture).to eq "x86_64"
+      end
+    end
+  end
+
+  context "for a version of el that is not added to our matrix" do
+    let(:channel) { :stable }
+    let(:product_name) { "delivery-cli" }
+    let(:product_version) { :latest }
+    let(:platform) { "el" }
+    let(:platform_version) { "8" }
+    let(:architecture) { "x86_64" }
+
+    it "can not find an artifact" do
+      expect(artifact_info).to be_empty
+    end
+
+    context "when product_version compat mode is set" do
+      let(:pv_compat) { true }
+
+      it "finds an artifact" do
+        expect(artifact_info).to be_a Mixlib::Install::ArtifactInfo
+        expect(artifact_info.platform).to eq "el"
+        expect(artifact_info.platform_version).to eq "7"
+        expect(artifact_info.architecture).to eq "x86_64"
+      end
     end
   end
 

--- a/spec/mixlib/install_spec.rb
+++ b/spec/mixlib/install_spec.rb
@@ -23,12 +23,18 @@ context "Mixlib::Install" do
     Mixlib::Install.new(
       product_name: product_name,
       channel: channel,
-      product_version: product_version
+      product_version: product_version,
+      platform: platform,
+      platform_version: platform_version,
+      architecture: architecture
     )
   end
 
   let(:channel) { :stable }
   let(:product_version) { :latest }
+  let(:platform) { nil }
+  let(:platform_version) { nil }
+  let(:architecture) { nil }
 
   context "querying current version" do
     let(:version_manifest_file) { "/opt/#{product_name}/version-manifest.json" }
@@ -128,14 +134,6 @@ context "Mixlib::Install" do
       let(:current_version) { nil }
 
       it "should report upgrade available" do
-        installer = Mixlib::Install.new(
-          product_name: product_name,
-          channel: channel,
-          product_version: product_version,
-          platform: platform,
-          platform_version: platform_version,
-          architecture: architecture
-        )
         expect(installer.upgrade_available?).to eq(true)
       end
     end


### PR DESCRIPTION
As a user, I would like to be able to consume Chef packages on new platforms that Chef Software Inc. did not have a chance to add to its official support matrix.

As distro release new versions, it takes us some time to add them into our official support matrix which requires adding new testers and builders to our CI infrastructure. Sometimes we do this in a timely manner but even these cases we have some adventurous users who would like to try Chef on these new versions before they become publicly available.

To satisfy these scenarios this PR adds in an opt-in functionality to mixlib-install and chef-ingredient which lets users get the packages built and tested for the latest version if we do not have their specified version in our official support matrix.

As a note, we have always had this functionality previously under the name "yolo".

- [x] Chat with @schisamo and test this in the currently broken delivery-cluster scenario.
- [x] Investigate if we need to change the name of this new option. If you have any new suggestions please drop it in as a comment. A few guidelines:
  - we do not want to use abbreviations that are hard to understand like `yolo` or `pv`.
  - we do not want to make the name scary like `allow_unstable` or `allow_unsafe`.
  - we do not want to make the name generic since we might introduce more options for backwards compatibility in the future outside platform_version.

/cc: @chef/engineering-services 