### PR TITLE
Added support for retrying msi installation for exit code 1618

### DIFF
--- a/support/install_command.ps1
+++ b/support/install_command.ps1
@@ -44,7 +44,6 @@ Function Download-Chef($url, $sha256, $dst) {
 Function Install-Chef($msi) {
   Log "Installing Chef Omnibus package $msi"
   $installingChef = $True
-  $installAttempts = 0
   while ($installingChef) {
     $installAttempts++
     $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi" -Passthru -Wait

--- a/support/install_command.ps1
+++ b/support/install_command.ps1
@@ -44,6 +44,7 @@ Function Download-Chef($url, $sha256, $dst) {
 Function Install-Chef($msi) {
   Log "Installing Chef Omnibus package $msi"
   $installingChef = $True
+  $installAttempts = 0
   while ($installingChef) {
     $installAttempts++
     $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi" -Passthru -Wait

--- a/support/install_command.ps1
+++ b/support/install_command.ps1
@@ -52,7 +52,7 @@ Function Install-Chef($msi) {
     $p.WaitForExit()
     if ($p.ExitCode -ne 0) {
       if ($installAttempts -gt $maxAttempts) {
-        throw "msiexec was not successful, exceeded retry limit (10).  Received exit code $($p.ExitCode)"
+        throw "msiexec was not successful, exceeded retry limit ($($maxAttempts)).  Received exit code $($p.ExitCode)"
       } elseif ($p.ExitCode -ne 1618) {
         throw "msiexec was not successful. Received exit code $($p.ExitCode)"
       } else {

--- a/support/install_command.ps1
+++ b/support/install_command.ps1
@@ -45,20 +45,15 @@ Function Install-Chef($msi) {
   Log "Installing Chef Omnibus package $msi"
   $installingChef = $True
   $installAttempts = 0
-  $maxAttempts = 10
   while ($installingChef) {
-    $installAttempts++;
+    $installAttempts++
     $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi" -Passthru -Wait
     $p.WaitForExit()
-    if ($p.ExitCode -ne 0) {
-      if ($installAttempts -gt $maxAttempts) {
-        throw "msiexec was not successful, exceeded retry limit ($($maxAttempts)).  Received exit code $($p.ExitCode)"
-      } elseif ($p.ExitCode -ne 1618) {
-        throw "msiexec was not successful. Received exit code $($p.ExitCode)"
-      } else {
-        Log "Another msi install is in progress (exit code 1618), retrying..."
-        continue
-      }
+    if ($p.ExitCode -eq 1618) {
+      Log "Another msi install is in progress (exit code 1618), retrying ($($installAttempts))..."
+      continue
+    } elseif ($p.ExitCode -ne 0) {
+      throw "msiexec was not successful. Received exit code $($p.ExitCode)"
     }
     $installingChef = $False
   }


### PR DESCRIPTION
Chef provisioning would constantly fail to install the chef client msi on our openstack windows nodes due to another msi installation already being in progress.  Added some simple retry code to detect exit code 1618 (another install in progress) and retry the installation.  Retries 10 times, although it usually works after 1 or 2.  Verified this works using latest chefdk (13.21).