### PR TITLE
Remove project validation in `install_project.ps1`

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
@@ -16,11 +16,6 @@ function Install-Project {
   [cmdletbinding(SupportsShouldProcess=$true)]
   param (
     # Project to install
-    # chef - Chef Client
-    # chefdk - Chef Development Kit
-    # angrychef - AngryChef
-    # server and container are not valid windows targets
-    [validateset('chef', 'chefdk', 'angrychef')]
     [string]
     $project = 'chef',
     # Release channel to install from


### PR DESCRIPTION
This brings the generated PowerShell script into parity with the Bourne version which does not do any project-level validation. It also allows some additional projects to be properly installed on Windows:

* delivery-cli
* push-jobs-client

/cc @chef/engineering-services 