### PR TITLE
Normalize the architecture we detected in platform detection script.

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -150,6 +150,19 @@ case $platform in
     ;;
 esac
 
+# normalize the architecture we detected
+case $machine in
+  "x86_64"|"amd64"|"x64")
+    machine="x86_64"
+    ;;
+  "i386"|"i86pc"|"x86"|"i686")
+    machine="i386"
+    ;;
+  "sparc"|"sun4u"|"sun4v")
+    machine="sparc"
+    ;;
+esac
+
 if test "x$platform_version" = "x"; then
   echo "Unable to determine platform version!"
   report_bug


### PR DESCRIPTION
This PR brings the architecture normalization logic we have in omnitruck to platform detection scripts:

https://github.com/chef/omnitruck/blob/master/app.rb#L322-L327

/cc: @chef/engineering-services 

Testing on a 32 bit ubuntu box, notice the changed value of `:architecture`. Also tested on solaris box to make sure I am not using some fancy bash construct.

```
serdar@ip-10-194-11-63:~/mixlib-install$ bundle exec irb
irb(main):001:0> require "mixlib/install"
=> true
irb(main):002:0> Mixlib::Install.new(product_name: "chef", product_version: :latest, channel: :stable).detect_platform
=> #<Mixlib::Install:0xb989aa08 @options=#<Mixlib::Install::Options:0xb989a9f4 @options={:product_name=>"chef", :product_version=>:latest, :channel=>:stable, :platform=>"ubuntu", :platform_version=>"12.04", :architecture=>"i686"}>>
irb(main):003:0> exit
serdar@ip-10-194-11-63:~/mixlib-install$ git fetch
Warning: Permanently added the RSA host key for IP address '192.30.252.128' to the list of known hosts.
remote: Counting objects: 9, done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 9 (delta 0), reused 0 (delta 0), pack-reused 0
Unpacking objects: 100% (9/9), done.
From github.com:chef/mixlib-install
 * [new branch]      sersut/arch-norm -> origin/sersut/arch-norm
serdar@ip-10-194-11-63:~/mixlib-install$ git checkout sersut/arch-norm
Branch sersut/arch-norm set up to track remote branch sersut/arch-norm from origin.
Switched to a new branch 'sersut/arch-norm'
serdar@ip-10-194-11-63:~/mixlib-install$ bundle exec irb
irb(main):001:0> require "mixlib/install"
=> true
irb(main):002:0> Mixlib::Install.new(product_name: "chef", product_version: :latest, channel: :stable).detect_platform
=> #<Mixlib::Install:0xb9b861a4 @options=#<Mixlib::Install::Options:0xb9b86190 @options={:product_name=>"chef", :product_version=>:latest, :channel=>:stable, :platform=>"ubuntu", :platform_version=>"12.04", :architecture=>"i386"}>>
irb(main):003:0> exit
```