### PR TITLE
Platform Architecture Detection on stable

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
@@ -53,13 +53,8 @@ function Get-ProjectMetadata {
   $platform_version = Get-PlatformVersion
   Write-Verbose "Platform Version: $platform_version"
 
-  # Custom architecture detection based on channel
   if ($architecture -eq 'auto') {
-    if (((get-wmiobject win32_operatingsystem).osarchitecture -like '64-bit') -and ($channel -like 'current')) {
-      $architecture = 'x86_64'
-    } else {
-      $architecture = 'i386'
-    }
+    $architecture = Get-PlatformArchitecture
   }
 
   Write-Verbose "Architecture: $architecture"

--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1
@@ -21,7 +21,13 @@ function Get-PlatformArchitecture {
 function New-Uri {
   param ($baseuri, $newuri)
 
+  try {
   new-object System.Uri $baseuri, $newuri
+  }
+  catch [System.Management.Automation.MethodInvocationException]{
+    Write-Error "$($_.exception.message)"
+    throw $_.exception
+  }
 }
 
 function Get-WebContent {


### PR DESCRIPTION
Previously, since we only published i386 builds on omnitruck stable, there was logic to prevent autodetection of the platform architecture.

For the most part omnitruck metadata does the right thing if the real architecture is passed to stable.  Also, we have x86_64 builds of chef-client and deliver-cli in stable which could now be picked up by default (and i386 systems will just not see them).

Also added a bit more error handling around `new-uri` to stop the commands if there is an invalid uri, rather than showing an error and continuing to try to download.