### PR TITLE
change machine architecture detection to use getconf

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -22,7 +22,14 @@
 # endpoint out there).
 #
 
-machine=`uname -m`
+case "$(getconf LONG_BIT)" in
+  "64")
+    machine=x86_64
+    ;;
+  "32")
+    machine=i386
+    ;;
+esac
 os=`uname -s`
 
 if test -f "/etc/lsb-release" && grep -q DISTRIB_ID /etc/lsb-release && ! grep -q wrlinux /etc/lsb-release; then


### PR DESCRIPTION
Using `getconf LONG_BIT` is a more reliable determination of
architecture.  `uname -m` will report the architecture of container
host, not the container.
