### PR TITLE
fix omnibus_project method

### DIFF
--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -72,7 +72,7 @@ module Mixlib
       #
       def omnibus_project(value = nil)
         if value.nil?
-          @omnibus_project || @package_name
+          @omnibus_project || package_name
         else
           @omnibus_project = value
         end
@@ -265,7 +265,7 @@ PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
   end
 
   product "push-jobs-client" do
-    product_name "Chef Push Server"
+    product_name "Chef Push Client"
     package_name do |v|
       v < version_for("1.3.0") ? "opscode-push-jobs-client" : "push-jobs-client"
     end

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_Artifactory_all_channels/for_manage/for_latest_version/uses_omnibus_project_name.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_Artifactory_all_channels/for_manage/for_latest_version/uses_omnibus_project_name.yml
@@ -1,0 +1,3955 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/build/chef-manage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:04 GMT
+      Content-Type:
+      - application/vnd.org.jfrog.build.BuildsByName+json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "buildsNumbers" : [ {
+            "uri" : "/2.4.0+20160624093519.git.6.7e0b311",
+            "started" : "2016-06-24T12:13:02.515+0000"
+          }, {
+            "uri" : "/2.2.0",
+            "started" : "2016-03-07T16:50:25.889+0000"
+          }, {
+            "uri" : "/2.3.0+20160610231633.git.40.d8d19d7",
+            "started" : "2016-06-10T23:59:51.072+0000"
+          }, {
+            "uri" : "/2.4.0+20160618093523.git.3.1f1b498",
+            "started" : "2016-06-18T12:07:49.072+0000"
+          }, {
+            "uri" : "/2.4.0+20160615093527",
+            "started" : "2016-06-15T12:08:52.542+0000"
+          }, {
+            "uri" : "/2.1.0",
+            "started" : "2015-11-24T20:33:45.631+0000"
+          }, {
+            "uri" : "/2.4.0+20160625093522.git.6.7e0b311",
+            "started" : "2016-06-25T12:10:39.735+0000"
+          }, {
+            "uri" : "/2.4.0+20160707093522.git.8.9159db4",
+            "started" : "2016-07-07T12:08:48.915+0000"
+          }, {
+            "uri" : "/2.4.0+20160626093520.git.6.7e0b311",
+            "started" : "2016-06-26T12:14:13.149+0000"
+          }, {
+            "uri" : "/2.3.0+20160608142229.git.26.1ff459a",
+            "started" : "2016-06-08T15:05:57.219+0000"
+          }, {
+            "uri" : "/2.4.0+20160622093526.git.3.1f1b498",
+            "started" : "2016-06-22T12:09:17.359+0000"
+          }, {
+            "uri" : "/2.4.0+20160701093527.git.8.9159db4",
+            "started" : "2016-07-01T12:11:58.264+0000"
+          }, {
+            "uri" : "/2.3.0+20160607211633.git.24.a9720bc",
+            "started" : "2016-06-07T22:00:25.658+0000"
+          }, {
+            "uri" : "/2.3.0+20160612093524.git.40.d8d19d7",
+            "started" : "2016-06-12T12:07:03.059+0000"
+          }, {
+            "uri" : "/2.3.0+20160609093521.git.30.0e9cb50",
+            "started" : "2016-06-09T12:06:19.537+0000"
+          }, {
+            "uri" : "/2.4.0+20160622164631.git.6.7e0b311",
+            "started" : "2016-06-22T17:16:14.045+0000"
+          }, {
+            "uri" : "/2.3.0+20160607093524.git.18.11255c1",
+            "started" : "2016-06-07T12:13:12.412+0000"
+          }, {
+            "uri" : "/2.4.0+20160616212241.git.3.1f1b498",
+            "started" : "2016-06-16T22:06:35.667+0000"
+          }, {
+            "uri" : "/2.4.0+20160627093522.git.6.7e0b311",
+            "started" : "2016-06-27T12:11:14.109+0000"
+          }, {
+            "uri" : "/2.3.0+20160608194633.git.30.0e9cb50",
+            "started" : "2016-06-08T20:29:40.147+0000"
+          }, {
+            "uri" : "/2.4.0+20160617093523.git.3.1f1b498",
+            "started" : "2016-06-17T12:08:16.906+0000"
+          }, {
+            "uri" : "/2.4.0+20160619093524.git.3.1f1b498",
+            "started" : "2016-06-19T12:08:00.231+0000"
+          }, {
+            "uri" : "/2.4.0+20160620093525.git.3.1f1b498",
+            "started" : "2016-06-20T12:07:59.076+0000"
+          }, {
+            "uri" : "/2.3.0+20160614224639.git.43.87e24f1",
+            "started" : "2016-06-14T23:29:22.306+0000"
+          }, {
+            "uri" : "/2.3.0+20160611093523.git.40.d8d19d7",
+            "started" : "2016-06-11T12:06:32.138+0000"
+          }, {
+            "uri" : "/2.3.0+20160613093522.git.40.d8d19d7",
+            "started" : "2016-06-13T12:08:01.352+0000"
+          }, {
+            "uri" : "/2.2.1",
+            "started" : "2016-04-04T19:50:54.490+0000"
+          }, {
+            "uri" : "/2.4.0",
+            "started" : "2016-06-14T23:54:43.724+0000"
+          }, {
+            "uri" : "/2.3.0+20160614093523.git.40.d8d19d7",
+            "started" : "2016-06-14T12:06:30.785+0000"
+          }, {
+            "uri" : "/2.3.0",
+            "started" : "2016-04-20T20:57:18.716+0000"
+          }, {
+            "uri" : "/2.4.0+20160616093527",
+            "started" : "2016-06-16T12:07:41.996+0000"
+          }, {
+            "uri" : "/2.3.0+20160610093526.git.38.7b195c3",
+            "started" : "2016-06-10T12:08:21.112+0000"
+          }, {
+            "uri" : "/2.4.0+20160705093523.git.8.9159db4",
+            "started" : "2016-07-05T12:07:20.874+0000"
+          }, {
+            "uri" : "/2.4.0+20160703093522.git.8.9159db4",
+            "started" : "2016-07-03T12:12:49.549+0000"
+          }, {
+            "uri" : "/2.3.0+20160607180436.git.20.41df01d",
+            "started" : "2016-06-07T18:32:33.811+0000"
+          }, {
+            "uri" : "/2.4.0+20160623093523.git.6.7e0b311",
+            "started" : "2016-06-23T12:09:11.897+0000"
+          }, {
+            "uri" : "/2.4.0+20160614231035",
+            "started" : "2016-06-15T00:20:46.015+0000"
+          }, {
+            "uri" : "/2.3.0+20160608093520.git.24.a9720bc",
+            "started" : "2016-06-08T12:06:52.278+0000"
+          }, {
+            "uri" : "/2.4.0+20160628093523.git.6.7e0b311",
+            "started" : "2016-06-28T12:17:09.665+0000"
+          }, {
+            "uri" : "/2.1.1",
+            "started" : "2015-12-01T02:29:48.359+0000"
+          }, {
+            "uri" : "/2.3.0+20160609175033.git.32.cc3be4e",
+            "started" : "2016-06-09T18:34:04.134+0000"
+          }, {
+            "uri" : "/2.4.0+20160629093522.git.6.7e0b311",
+            "started" : "2016-06-29T12:13:55.308+0000"
+          }, {
+            "uri" : "/2.4.0+20160630163635.git.8.9159db4",
+            "started" : "2016-06-30T17:19:58.068+0000"
+          }, {
+            "uri" : "/2.4.0+20160630093529.git.6.7e0b311",
+            "started" : "2016-06-30T12:12:54.987+0000"
+          }, {
+            "uri" : "/2.4.0+20160704093524.git.8.9159db4",
+            "started" : "2016-07-04T12:12:44.657+0000"
+          }, {
+            "uri" : "/2.1.2",
+            "started" : "2016-01-26T19:08:13.949+0000"
+          }, {
+            "uri" : "/2.3.0+20160609220239.git.36.dde86a7",
+            "started" : "2016-06-09T22:59:24.215+0000"
+          }, {
+            "uri" : "/2.4.0+20160702093527.git.8.9159db4",
+            "started" : "2016-07-02T12:11:54.766+0000"
+          }, {
+            "uri" : "/2.4.0+20160621093524.git.3.1f1b498",
+            "started" : "2016-06-21T12:07:52.942+0000"
+          }, {
+            "uri" : "/2.3.0+20160609205232.git.34.6bf1ecc",
+            "started" : "2016-06-09T22:16:18.918+0000"
+          }, {
+            "uri" : "/2.3.0+20160608175435.git.28.62f196f",
+            "started" : "2016-06-08T19:07:54.230+0000"
+          } ],
+          "uri" : "http://artifactory.chef.co/api/build/chef-manage"
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:59 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160707093522.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:59 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160705093523.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:05 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:00 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160704093524.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:05 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:00 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160703093522.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:06 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:01 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160702093527.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:06 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:01 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160701093527.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:06 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:01 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160630163635.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:02 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160630093529.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:02 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160629093522.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:02 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160628093523.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:03 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160627093522.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:03 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160626093520.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:03 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160625093522.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:04 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160624093519.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:04 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160623093523.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:04 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160622164631.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:05 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160622093526.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:05 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160621093524.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:06 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160620093525.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:06 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160619093524.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:06 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160618093523.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:12 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:07 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160617093523.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:12 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:07 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160616212241.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:12 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:07 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160616093527"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:13 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:08 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160615093527"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:13 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:08 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160614231035"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:13 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:08 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chef-manage/2.4.0/ubuntu/12.04",
+          "name" : "chef-manage_2.4.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "6e807813044e8e9c1dd63f18eeb76018"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.4.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "9ee2be5c58b2cc72ab61f5241db81df3a7e6f7029e07146b37a7daf8b367cf3318609526f490c6c1f29eeae2c4284fda73e739f71be428c158fb019af5b3d934"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "728daffb492bf450b966523bae85647fff0e1c63ff552c75a4e8ad8f79692559"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Chef-MLSA"
+          }, {
+            "key" : "build.name",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "84274cb6d511a40f69fed58241c2b891a2d4bff0"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chef-manage/2.4.0/el/7",
+          "name" : "chef-manage-2.4.0-1.el7.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "f55f9844c2f91815ea40ba115079957a5e3c183a287d3d0fc943ccc8b9ef06eaed772945f0aca87819558186ba93bc56d89cc7e8ba819a837d8bd8236966cfe8"
+          }, {
+            "key" : "build.number",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "73a06e82ab1479f110afddad7152ca06"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Chef-MLSA"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "1b136be0a4cb55977f33d1ce8fbcd5c7c6d17eda3238750c4527b7312de13c50"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.name",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "7c817975d954b59692e45f697b1201b9afa80b2a"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chef-manage/2.4.0/ubuntu/14.04",
+          "name" : "chef-manage_2.4.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha256",
+            "value" : "728daffb492bf450b966523bae85647fff0e1c63ff552c75a4e8ad8f79692559"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "9ee2be5c58b2cc72ab61f5241db81df3a7e6f7029e07146b37a7daf8b367cf3318609526f490c6c1f29eeae2c4284fda73e739f71be428c158fb019af5b3d934"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chef-manage"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Chef-MLSA"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "6e807813044e8e9c1dd63f18eeb76018"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "84274cb6d511a40f69fed58241c2b891a2d4bff0"
+          }, {
+            "key" : "build.name",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chef-manage/2.4.0/el/5",
+          "name" : "chef-manage-2.4.0-1.el5.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "eb42ade9056f5d94c2aa2a4eb6b95afb9741a994"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Chef-MLSA"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "d18e10a0a675089618bbdf3aeec8eba0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "build.name",
+            "value" : "chef-manage"
+          }, {
+            "key" : "build.number",
+            "value" : "2.4.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "0e46ffd463fa1bc56cd1d3cc7bd95d6a77d805d88f9d92c8cfa986191c275eb2"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "4ea71afa4b55679a62d4634f651a552d62180cdfdecf1d422113f8a4cd2ecbb0b2daf5ba219f71adf58fd88ce558c50f5bf3e33f31a501b43f9a60533c140677"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chef-manage/2.4.0/el/6",
+          "name" : "chef-manage-2.4.0-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.sha256",
+            "value" : "32322dc7be6199a1b56e0d9e486d3d45394d6be30c9013ea0fecc45452df5f28"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Chef-MLSA"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "791e6b760b3749a0a84ece813228136937fed1fa90eb44659b3d318b1fe0f81d5011dabd35c97b09e654f6dc4a5a763bbdacf2fbe3867a2c9150adb0a4d58ea3"
+          }, {
+            "key" : "build.name",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dbd9f34fa23b725a5642752582e2b646"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "d6b220e496229cfbaeab95f766406bde29887848"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "build.number",
+            "value" : "2.4.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 5,
+          "total" : 5
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:09 GMT
+- request:
+    method: get
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/build/chef-manage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:14 GMT
+      Content-Type:
+      - application/vnd.org.jfrog.build.BuildsByName+json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "buildsNumbers" : [ {
+            "uri" : "/2.4.0+20160624093519.git.6.7e0b311",
+            "started" : "2016-06-24T12:13:02.515+0000"
+          }, {
+            "uri" : "/2.2.0",
+            "started" : "2016-03-07T16:50:25.889+0000"
+          }, {
+            "uri" : "/2.3.0+20160610231633.git.40.d8d19d7",
+            "started" : "2016-06-10T23:59:51.072+0000"
+          }, {
+            "uri" : "/2.4.0+20160618093523.git.3.1f1b498",
+            "started" : "2016-06-18T12:07:49.072+0000"
+          }, {
+            "uri" : "/2.4.0+20160615093527",
+            "started" : "2016-06-15T12:08:52.542+0000"
+          }, {
+            "uri" : "/2.1.0",
+            "started" : "2015-11-24T20:33:45.631+0000"
+          }, {
+            "uri" : "/2.4.0+20160625093522.git.6.7e0b311",
+            "started" : "2016-06-25T12:10:39.735+0000"
+          }, {
+            "uri" : "/2.4.0+20160707093522.git.8.9159db4",
+            "started" : "2016-07-07T12:08:48.915+0000"
+          }, {
+            "uri" : "/2.4.0+20160626093520.git.6.7e0b311",
+            "started" : "2016-06-26T12:14:13.149+0000"
+          }, {
+            "uri" : "/2.3.0+20160608142229.git.26.1ff459a",
+            "started" : "2016-06-08T15:05:57.219+0000"
+          }, {
+            "uri" : "/2.4.0+20160622093526.git.3.1f1b498",
+            "started" : "2016-06-22T12:09:17.359+0000"
+          }, {
+            "uri" : "/2.4.0+20160701093527.git.8.9159db4",
+            "started" : "2016-07-01T12:11:58.264+0000"
+          }, {
+            "uri" : "/2.3.0+20160607211633.git.24.a9720bc",
+            "started" : "2016-06-07T22:00:25.658+0000"
+          }, {
+            "uri" : "/2.3.0+20160612093524.git.40.d8d19d7",
+            "started" : "2016-06-12T12:07:03.059+0000"
+          }, {
+            "uri" : "/2.3.0+20160609093521.git.30.0e9cb50",
+            "started" : "2016-06-09T12:06:19.537+0000"
+          }, {
+            "uri" : "/2.4.0+20160622164631.git.6.7e0b311",
+            "started" : "2016-06-22T17:16:14.045+0000"
+          }, {
+            "uri" : "/2.3.0+20160607093524.git.18.11255c1",
+            "started" : "2016-06-07T12:13:12.412+0000"
+          }, {
+            "uri" : "/2.4.0+20160616212241.git.3.1f1b498",
+            "started" : "2016-06-16T22:06:35.667+0000"
+          }, {
+            "uri" : "/2.4.0+20160627093522.git.6.7e0b311",
+            "started" : "2016-06-27T12:11:14.109+0000"
+          }, {
+            "uri" : "/2.3.0+20160608194633.git.30.0e9cb50",
+            "started" : "2016-06-08T20:29:40.147+0000"
+          }, {
+            "uri" : "/2.4.0+20160617093523.git.3.1f1b498",
+            "started" : "2016-06-17T12:08:16.906+0000"
+          }, {
+            "uri" : "/2.4.0+20160619093524.git.3.1f1b498",
+            "started" : "2016-06-19T12:08:00.231+0000"
+          }, {
+            "uri" : "/2.4.0+20160620093525.git.3.1f1b498",
+            "started" : "2016-06-20T12:07:59.076+0000"
+          }, {
+            "uri" : "/2.3.0+20160614224639.git.43.87e24f1",
+            "started" : "2016-06-14T23:29:22.306+0000"
+          }, {
+            "uri" : "/2.3.0+20160611093523.git.40.d8d19d7",
+            "started" : "2016-06-11T12:06:32.138+0000"
+          }, {
+            "uri" : "/2.3.0+20160613093522.git.40.d8d19d7",
+            "started" : "2016-06-13T12:08:01.352+0000"
+          }, {
+            "uri" : "/2.2.1",
+            "started" : "2016-04-04T19:50:54.490+0000"
+          }, {
+            "uri" : "/2.4.0",
+            "started" : "2016-06-14T23:54:43.724+0000"
+          }, {
+            "uri" : "/2.3.0+20160614093523.git.40.d8d19d7",
+            "started" : "2016-06-14T12:06:30.785+0000"
+          }, {
+            "uri" : "/2.3.0",
+            "started" : "2016-04-20T20:57:18.716+0000"
+          }, {
+            "uri" : "/2.4.0+20160616093527",
+            "started" : "2016-06-16T12:07:41.996+0000"
+          }, {
+            "uri" : "/2.3.0+20160610093526.git.38.7b195c3",
+            "started" : "2016-06-10T12:08:21.112+0000"
+          }, {
+            "uri" : "/2.4.0+20160705093523.git.8.9159db4",
+            "started" : "2016-07-05T12:07:20.874+0000"
+          }, {
+            "uri" : "/2.4.0+20160703093522.git.8.9159db4",
+            "started" : "2016-07-03T12:12:49.549+0000"
+          }, {
+            "uri" : "/2.3.0+20160607180436.git.20.41df01d",
+            "started" : "2016-06-07T18:32:33.811+0000"
+          }, {
+            "uri" : "/2.4.0+20160623093523.git.6.7e0b311",
+            "started" : "2016-06-23T12:09:11.897+0000"
+          }, {
+            "uri" : "/2.4.0+20160614231035",
+            "started" : "2016-06-15T00:20:46.015+0000"
+          }, {
+            "uri" : "/2.3.0+20160608093520.git.24.a9720bc",
+            "started" : "2016-06-08T12:06:52.278+0000"
+          }, {
+            "uri" : "/2.4.0+20160628093523.git.6.7e0b311",
+            "started" : "2016-06-28T12:17:09.665+0000"
+          }, {
+            "uri" : "/2.1.1",
+            "started" : "2015-12-01T02:29:48.359+0000"
+          }, {
+            "uri" : "/2.3.0+20160609175033.git.32.cc3be4e",
+            "started" : "2016-06-09T18:34:04.134+0000"
+          }, {
+            "uri" : "/2.4.0+20160629093522.git.6.7e0b311",
+            "started" : "2016-06-29T12:13:55.308+0000"
+          }, {
+            "uri" : "/2.4.0+20160630163635.git.8.9159db4",
+            "started" : "2016-06-30T17:19:58.068+0000"
+          }, {
+            "uri" : "/2.4.0+20160630093529.git.6.7e0b311",
+            "started" : "2016-06-30T12:12:54.987+0000"
+          }, {
+            "uri" : "/2.4.0+20160704093524.git.8.9159db4",
+            "started" : "2016-07-04T12:12:44.657+0000"
+          }, {
+            "uri" : "/2.1.2",
+            "started" : "2016-01-26T19:08:13.949+0000"
+          }, {
+            "uri" : "/2.3.0+20160609220239.git.36.dde86a7",
+            "started" : "2016-06-09T22:59:24.215+0000"
+          }, {
+            "uri" : "/2.4.0+20160702093527.git.8.9159db4",
+            "started" : "2016-07-02T12:11:54.766+0000"
+          }, {
+            "uri" : "/2.4.0+20160621093524.git.3.1f1b498",
+            "started" : "2016-06-21T12:07:52.942+0000"
+          }, {
+            "uri" : "/2.3.0+20160609205232.git.34.6bf1ecc",
+            "started" : "2016-06-09T22:16:18.918+0000"
+          }, {
+            "uri" : "/2.3.0+20160608175435.git.28.62f196f",
+            "started" : "2016-06-08T19:07:54.230+0000"
+          } ],
+          "uri" : "http://artifactory.chef.co/api/build/chef-manage"
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:09 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160707093522.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:15 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:10 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160705093523.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:15 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:10 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160704093524.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:15 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:10 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160703093522.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:16 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:11 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160702093527.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:16 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:11 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160701093527.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:16 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:11 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160630163635.git.8.9159db4"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:17 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:12 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160630093529.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:17 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:12 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160629093522.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:17 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:12 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160628093523.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:18 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:13 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160627093522.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:18 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:13 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160626093520.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:19 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:13 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160625093522.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:19 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:14 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160624093519.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:19 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:14 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160623093523.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:15 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160622164631.git.6.7e0b311"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:15 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160622093526.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:15 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160621093524.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:16 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160620093525.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:16 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160619093524.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:16 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160618093523.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:17 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160617093523.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:17 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160616212241.git.3.1f1b498"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:17 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160616093527"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:18 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160615093527"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:18 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0+20160614231035"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:24 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:18 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "chef-manage"},
+          {"@omnibus.version": "2.4.0"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:24 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chef-manage/2.4.0/ubuntu/12.04",
+          "name" : "chef-manage_2.4.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "6e807813044e8e9c1dd63f18eeb76018"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.4.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "9ee2be5c58b2cc72ab61f5241db81df3a7e6f7029e07146b37a7daf8b367cf3318609526f490c6c1f29eeae2c4284fda73e739f71be428c158fb019af5b3d934"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "728daffb492bf450b966523bae85647fff0e1c63ff552c75a4e8ad8f79692559"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Chef-MLSA"
+          }, {
+            "key" : "build.name",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "84274cb6d511a40f69fed58241c2b891a2d4bff0"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chef-manage/2.4.0/el/7",
+          "name" : "chef-manage-2.4.0-1.el7.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "f55f9844c2f91815ea40ba115079957a5e3c183a287d3d0fc943ccc8b9ef06eaed772945f0aca87819558186ba93bc56d89cc7e8ba819a837d8bd8236966cfe8"
+          }, {
+            "key" : "build.number",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "73a06e82ab1479f110afddad7152ca06"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Chef-MLSA"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "1b136be0a4cb55977f33d1ce8fbcd5c7c6d17eda3238750c4527b7312de13c50"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.name",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "7c817975d954b59692e45f697b1201b9afa80b2a"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chef-manage/2.4.0/ubuntu/14.04",
+          "name" : "chef-manage_2.4.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha256",
+            "value" : "728daffb492bf450b966523bae85647fff0e1c63ff552c75a4e8ad8f79692559"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "9ee2be5c58b2cc72ab61f5241db81df3a7e6f7029e07146b37a7daf8b367cf3318609526f490c6c1f29eeae2c4284fda73e739f71be428c158fb019af5b3d934"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chef-manage"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Chef-MLSA"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "6e807813044e8e9c1dd63f18eeb76018"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "84274cb6d511a40f69fed58241c2b891a2d4bff0"
+          }, {
+            "key" : "build.name",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chef-manage/2.4.0/el/5",
+          "name" : "chef-manage-2.4.0-1.el5.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "eb42ade9056f5d94c2aa2a4eb6b95afb9741a994"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Chef-MLSA"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "d18e10a0a675089618bbdf3aeec8eba0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "build.name",
+            "value" : "chef-manage"
+          }, {
+            "key" : "build.number",
+            "value" : "2.4.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "0e46ffd463fa1bc56cd1d3cc7bd95d6a77d805d88f9d92c8cfa986191c275eb2"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "4ea71afa4b55679a62d4634f651a552d62180cdfdecf1d422113f8a4cd2ecbb0b2daf5ba219f71adf58fd88ce558c50f5bf3e33f31a501b43f9a60533c140677"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chef-manage/2.4.0/el/6",
+          "name" : "chef-manage-2.4.0-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.sha256",
+            "value" : "32322dc7be6199a1b56e0d9e486d3d45394d6be30c9013ea0fecc45452df5f28"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Chef-MLSA"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "791e6b760b3749a0a84ece813228136937fed1fa90eb44659b3d318b1fe0f81d5011dabd35c97b09e654f6dc4a5a763bbdacf2fbe3867a2c9150adb0a4d58ea3"
+          }, {
+            "key" : "build.name",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dbd9f34fa23b725a5642752582e2b646"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.4.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chef-manage"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "d6b220e496229cfbaeab95f766406bde29887848"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "build.number",
+            "value" : "2.4.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 5,
+          "total" : 5
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:11:19 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_Artifactory_all_channels/for_manage/for_version_1_21_0/uses_omnibus_project_name.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_Artifactory_all_channels/for_manage/for_version_1_21_0/uses_omnibus_project_name.yml
@@ -1,0 +1,609 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "opscode-manage"},
+          {"@omnibus.version": "1.21.0"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:03 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-manage/1.21.0/ubuntu/10.04",
+          "name" : "opscode-manage_1.21.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "build.number",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "84582862ce47d5f6db1e1ed89021c4b8efbda847"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "4291b3760313922bc5a5116b81c2c72dd12e695e2bccec47a6eb758107664287271ca73fb1394851e731695e915a5180ec37aa769585e6ce6678a9ddd5c9fcc4"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.04"
+          }, {
+            "key" : "build.name",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "0e78f58653b70a5f355e8bd0a5a763e52a32ce13d6a7b292b3c53537f7f336c5"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "48e65752b37c1a8457ee76b79dd6db36"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-manage/1.21.0/el/7",
+          "name" : "opscode-manage-1.21.0-1.el7.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "build.number",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ff33f73d15e19f82533439b78ba6381cb290272cb485b905b42cab0b33465179c9deca16005c7f58096323526f045e31fa2c57e2107dac30c7aa98e5dd424c97"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "98bae9dabb346d8315e8e1d2a14bc44a165b566c7ee42b3c6de60901e097d23a"
+          }, {
+            "key" : "build.name",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "1b12e6c3d52b5809fa9d1507a4b3f40a26c875dd"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "b05d3b2e8aba15868475b2282ce554ce"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-manage/1.21.0/ubuntu/14.04",
+          "name" : "opscode-manage_1.21.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "build.number",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "4291b3760313922bc5a5116b81c2c72dd12e695e2bccec47a6eb758107664287271ca73fb1394851e731695e915a5180ec37aa769585e6ce6678a9ddd5c9fcc4"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "0e78f58653b70a5f355e8bd0a5a763e52a32ce13d6a7b292b3c53537f7f336c5"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "84582862ce47d5f6db1e1ed89021c4b8efbda847"
+          }, {
+            "key" : "build.name",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "48e65752b37c1a8457ee76b79dd6db36"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-manage/1.21.0/ubuntu/12.04",
+          "name" : "opscode-manage_1.21.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "48e65752b37c1a8457ee76b79dd6db36"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "84582862ce47d5f6db1e1ed89021c4b8efbda847"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "4291b3760313922bc5a5116b81c2c72dd12e695e2bccec47a6eb758107664287271ca73fb1394851e731695e915a5180ec37aa769585e6ce6678a9ddd5c9fcc4"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "0e78f58653b70a5f355e8bd0a5a763e52a32ce13d6a7b292b3c53537f7f336c5"
+          }, {
+            "key" : "build.name",
+            "value" : "opscode-manage"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-manage/1.21.0/el/6",
+          "name" : "opscode-manage-1.21.0-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "build.number",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "b77723eb39e775c4ee892d59b785a8ba"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "660a805c8633c601740371ddbc12ec4dc0c76f1777400e63ffe42afac25187a0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "2820a1d07e77dd7b945bd66d5f91910de10a5fc8"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "4d4b2fe01ed82a7b2a221551a09e8101b44d892a6104bb9fd4c633cbbb87f7118d939fe83b023785ac1ce0128ede9cae9ac9373b76d2a78aba2102a4a5d93fc8"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "build.name",
+            "value" : "opscode-manage"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-manage/1.21.0/el/5",
+          "name" : "opscode-manage-1.21.0-1.el5.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "06909f1cbb416268139cb3632b671e73cd3707f15714653944637aa5b27b43d60c3228373d16f3c82e6abedea636078568a2f4e6bb74e287329b9ca188b01e6e"
+          }, {
+            "key" : "build.number",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "ddbd250e7d10dc1ea97d65295be5a7a1146a83cae15cd76dece0a2a34dfc9915"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "6b667e40f025a510796421111760dfeb64b6698c"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "61ea1f942b8836ab3a57dc86dca241db"
+          }, {
+            "key" : "build.name",
+            "value" : "opscode-manage"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 6,
+          "total" : 6
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:58 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "opscode-manage"},
+          {"@omnibus.version": "1.21.0"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-manage/1.21.0/ubuntu/10.04",
+          "name" : "opscode-manage_1.21.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "build.number",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "84582862ce47d5f6db1e1ed89021c4b8efbda847"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "4291b3760313922bc5a5116b81c2c72dd12e695e2bccec47a6eb758107664287271ca73fb1394851e731695e915a5180ec37aa769585e6ce6678a9ddd5c9fcc4"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.04"
+          }, {
+            "key" : "build.name",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "0e78f58653b70a5f355e8bd0a5a763e52a32ce13d6a7b292b3c53537f7f336c5"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "48e65752b37c1a8457ee76b79dd6db36"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-manage/1.21.0/el/7",
+          "name" : "opscode-manage-1.21.0-1.el7.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "build.number",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ff33f73d15e19f82533439b78ba6381cb290272cb485b905b42cab0b33465179c9deca16005c7f58096323526f045e31fa2c57e2107dac30c7aa98e5dd424c97"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "98bae9dabb346d8315e8e1d2a14bc44a165b566c7ee42b3c6de60901e097d23a"
+          }, {
+            "key" : "build.name",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "1b12e6c3d52b5809fa9d1507a4b3f40a26c875dd"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "b05d3b2e8aba15868475b2282ce554ce"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-manage/1.21.0/ubuntu/14.04",
+          "name" : "opscode-manage_1.21.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "build.number",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "4291b3760313922bc5a5116b81c2c72dd12e695e2bccec47a6eb758107664287271ca73fb1394851e731695e915a5180ec37aa769585e6ce6678a9ddd5c9fcc4"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "0e78f58653b70a5f355e8bd0a5a763e52a32ce13d6a7b292b3c53537f7f336c5"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "84582862ce47d5f6db1e1ed89021c4b8efbda847"
+          }, {
+            "key" : "build.name",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "48e65752b37c1a8457ee76b79dd6db36"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-manage/1.21.0/ubuntu/12.04",
+          "name" : "opscode-manage_1.21.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "48e65752b37c1a8457ee76b79dd6db36"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "84582862ce47d5f6db1e1ed89021c4b8efbda847"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "4291b3760313922bc5a5116b81c2c72dd12e695e2bccec47a6eb758107664287271ca73fb1394851e731695e915a5180ec37aa769585e6ce6678a9ddd5c9fcc4"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "0e78f58653b70a5f355e8bd0a5a763e52a32ce13d6a7b292b3c53537f7f336c5"
+          }, {
+            "key" : "build.name",
+            "value" : "opscode-manage"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-manage/1.21.0/el/6",
+          "name" : "opscode-manage-1.21.0-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "build.number",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "b77723eb39e775c4ee892d59b785a8ba"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "660a805c8633c601740371ddbc12ec4dc0c76f1777400e63ffe42afac25187a0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "2820a1d07e77dd7b945bd66d5f91910de10a5fc8"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "4d4b2fe01ed82a7b2a221551a09e8101b44d892a6104bb9fd4c633cbbb87f7118d939fe83b023785ac1ce0128ede9cae9ac9373b76d2a78aba2102a4a5d93fc8"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "build.name",
+            "value" : "opscode-manage"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-manage/1.21.0/el/5",
+          "name" : "opscode-manage-1.21.0-1.el5.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "06909f1cbb416268139cb3632b671e73cd3707f15714653944637aa5b27b43d60c3228373d16f3c82e6abedea636078568a2f4e6bb74e287329b9ca188b01e6e"
+          }, {
+            "key" : "build.number",
+            "value" : "1.21.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "ddbd250e7d10dc1ea97d65295be5a7a1146a83cae15cd76dece0a2a34dfc9915"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-manage"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "6b667e40f025a510796421111760dfeb64b6698c"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "61ea1f942b8836ab3a57dc86dca241db"
+          }, {
+            "key" : "build.name",
+            "value" : "opscode-manage"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 6,
+          "total" : 6
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_Artifactory_all_channels/for_push_jobs_client/for_latest_version/uses_omnibus_project_name.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_Artifactory_all_channels/for_push_jobs_client/for_latest_version/uses_omnibus_project_name.yml
@@ -1,0 +1,6705 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/build/push-jobs-client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:42 GMT
+      Content-Type:
+      - application/vnd.org.jfrog.build.BuildsByName+json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "buildsNumbers" : [ {
+            "uri" : "/2.1.0+20160703080116",
+            "started" : "2016-07-03T08:35:43.637+0000"
+          }, {
+            "uri" : "/2.1.0+20160612080112",
+            "started" : "2016-06-12T08:43:34.559+0000"
+          }, {
+            "uri" : "/2.1.0+20160701080111",
+            "started" : "2016-07-01T08:36:27.055+0000"
+          }, {
+            "uri" : "/2.1.0+20160624080109",
+            "started" : "2016-06-24T08:35:45.713+0000"
+          }, {
+            "uri" : "/1.3.4",
+            "started" : "2015-11-04T03:14:39.286+0000"
+          }, {
+            "uri" : "/2.1.0+20160623080108",
+            "started" : "2016-06-23T08:35:30.989+0000"
+          }, {
+            "uri" : "/2.1.0+20160705080108",
+            "started" : "2016-07-05T08:35:48.858+0000"
+          }, {
+            "uri" : "/2.1.0+20160630080111",
+            "started" : "2016-06-30T08:35:46.574+0000"
+          }, {
+            "uri" : "/2.1.0+20160610080110",
+            "started" : "2016-06-10T08:43:53.665+0000"
+          }, {
+            "uri" : "/2.1.0",
+            "started" : "2016-05-17T19:09:27.709+0000"
+          }, {
+            "uri" : "/2.1.0+20160611080110",
+            "started" : "2016-06-11T08:43:37.191+0000"
+          }, {
+            "uri" : "/1.3.3",
+            "started" : "2015-09-18T00:58:22.412+0000"
+          }, {
+            "uri" : "/2.1.0+20160613080109",
+            "started" : "2016-06-13T08:43:24.459+0000"
+          }, {
+            "uri" : "/2.1.0+20160618080111",
+            "started" : "2016-06-18T08:35:41.022+0000"
+          }, {
+            "uri" : "/2.1.0+20160607080110",
+            "started" : "2016-06-07T08:58:07.616+0000"
+          }, {
+            "uri" : "/2.1.0+20160622080111",
+            "started" : "2016-06-22T08:35:39.315+0000"
+          }, {
+            "uri" : "/2.1.0+20160620080109",
+            "started" : "2016-06-20T08:35:47.564+0000"
+          }, {
+            "uri" : "/2.1.0+20160702080110",
+            "started" : "2016-07-02T08:35:35.852+0000"
+          }, {
+            "uri" : "/2.1.0+20160704080112",
+            "started" : "2016-07-04T08:35:45.130+0000"
+          }, {
+            "uri" : "/2.1.0+20160617080110",
+            "started" : "2016-06-17T08:45:35.598+0000"
+          } ],
+          "uri" : "http://artifactory.chef.co/api/build/push-jobs-client"
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:37 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160705080108"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:43 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:38 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160704080112"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:43 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:38 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160703080116"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:44 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:38 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160702080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:44 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:39 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160701080111"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:44 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:39 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160630080111"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:45 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:40 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160624080109"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:45 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:40 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160623080108"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:45 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:40 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160622080111"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:41 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160620080109"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:41 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160618080111"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:41 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160617080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:47 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:42 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160613080109"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:47 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:42 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160612080112"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:48 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:42 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160611080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:48 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:43 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160610080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:48 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:43 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160607080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:44 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/6",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha256",
+            "value" : "8948f700750729746d23692251e41d7694d6df379bafca324743d246cb7ed054"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "198c911b61253e5c93489bf1007ac2cb"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "facb8e7671e66c6b30c7c75e72fc7d4b6b35a8dd33eb589e8317759f7ead53d6b3fa2da14ea1d9bc09cd991f5e540bcd4cded285a012dbcdaca7edb3883a9748"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "d5affb4c8276fb435e901646dce62f40cc2c6efb"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/5",
+          "name" : "push-jobs-client-2.1.0-1.el5.i386.rpm",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "7190c62f9f8a23fdd2094a9d594e7bd94df8802e"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "171abb92f4db585c08a823c3966dd2d6c681b3b50ae03832c9ccaa8bb3829bc207977230940c16cfda14ae9111612cc0f524fd908b8004ec98bd24c1f67025ab"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "2d9d96c9001d6848cfd6e8b9e0f76e3df03008c4e74606a54346a3f2db2c80e0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "05df6f6ecff4af4e3a1890730b8e1a8b"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/12.04",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "89ed9c4d0ea8265f60cb94fd66c8fa5fb3f817f9c5884aa3180b56779aba71a303c2e7a2357f68f96369e3d00a990ad28ec01dc1df1124724837631d50331a9d"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "385cbee101c04c612532d4cafea2e8c08b8ae98183e31080407077840f134fd6"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "36b294b739cbc9f55387dd322281c41096ce9a72"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "c4105d75087f36c81826fd10e981eaee"
+          }, {
+            "key" : "delivery.sha"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/mac_os_x/10.9",
+          "name" : "push-jobs-client-2.1.0-1.dmg",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "65896d961f4c170c99735286dcd44ec6"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "d2b69aa1342f5b8fd9887473a1cfb01130cd5dfabf08acb5a8dfb90ad0f9012905c59e3ce3ca32cc7fb6ca7f29c2b41a3d35c83072964330648cc793345e6f1c"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.9"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "b3cf4f5d4626f879cd59b8c4a3a017ce017b07fc"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "77fd61f945ce59aa869955a134fd80ddd7754cc1d5d9a15fc43ec15d163bf07d"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/12.04",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "0f835a563b341d6a8340b1c8315a984a"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "47db96d66ed98be7db6fb97edd3552b4c436e01c27c34eaf26a8b87eaf548074"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "eb6ddc33a20fe01a38f7f4003941866debb48e2e"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "3240375c7b56cd3fa8d4755d644c456b61cd40a5fcf084494b04dc0555ffc88437ff566decfc3751b0e97e4176d1ef5e2a4aabded79268d834d3b351bc8d84f5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/8",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.platform_version",
+            "value" : "8"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f61067ba5ac78bf2e8c002782767c42fb4fde317"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd1e338eb4ba9a4b84cb04e2b01c34f797bbc8eef88d9cd1c9bbe80dff501ba9"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "349b704e7dbf7060e214d78f372346dc"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "fd4d5116263515ac6887cbd77ee731fa5e784d37bd511fece09716bbaefdf2ea83b88c2845eaa5ebbf79196820debc76a2316c460cf51e099e5773f1ce2f8817"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/6",
+          "name" : "push-jobs-client-2.1.0-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "abd157603b243b66ce23712ab66b3cf7"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "a3ac2f0033820310ff4f3fb3a287ad1afe1f57ae410cdc220aa89ed15a1c4a432d17a8bcc0b838c936ff6ffef62faed13e75522275144908272500918f2d67a4"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "913088585c9cf7319eaab4127d47cc173ebf4bf8"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "1eb8688e906697f2ad78eec8ca6fe0bbf137477fa09f2f2c90f8498ed7a67979"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/7",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "d5affb4c8276fb435e901646dce62f40cc2c6efb"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "8948f700750729746d23692251e41d7694d6df379bafca324743d246cb7ed054"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "198c911b61253e5c93489bf1007ac2cb"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "facb8e7671e66c6b30c7c75e72fc7d4b6b35a8dd33eb589e8317759f7ead53d6b3fa2da14ea1d9bc09cd991f5e540bcd4cded285a012dbcdaca7edb3883a9748"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/14.04",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "eb6ddc33a20fe01a38f7f4003941866debb48e2e"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "3240375c7b56cd3fa8d4755d644c456b61cd40a5fcf084494b04dc0555ffc88437ff566decfc3751b0e97e4176d1ef5e2a4aabded79268d834d3b351bc8d84f5"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "47db96d66ed98be7db6fb97edd3552b4c436e01c27c34eaf26a8b87eaf548074"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "0f835a563b341d6a8340b1c8315a984a"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/windows/2012",
+          "name" : "push-jobs-client-2.1.0-1-x86.msi",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "21c8614579593dd57c820fc06ad7fa09"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d86b37a67a12b0b91a1c25d4cdc0667721d80b74f5cd1891ff97597129b76b59"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "b3c02a1b2a89d2a351b8608218cf13a2c9d59d4073ef2f35e13f6d815d65bd94e3ccbf3fbb18f504b6c56eb37402558e228da3f4e48d82d8a81c801b81c32699"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a14a29b001c1e6d21c8d15192071f4854ce4184b"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/windows/2008r2",
+          "name" : "push-jobs-client-2.1.0-1-x86.msi",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "b3c02a1b2a89d2a351b8608218cf13a2c9d59d4073ef2f35e13f6d815d65bd94e3ccbf3fbb18f504b6c56eb37402558e228da3f4e48d82d8a81c801b81c32699"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "21c8614579593dd57c820fc06ad7fa09"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a14a29b001c1e6d21c8d15192071f4854ce4184b"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2008r2"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d86b37a67a12b0b91a1c25d4cdc0667721d80b74f5cd1891ff97597129b76b59"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/8",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "8948f700750729746d23692251e41d7694d6df379bafca324743d246cb7ed054"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "d5affb4c8276fb435e901646dce62f40cc2c6efb"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "198c911b61253e5c93489bf1007ac2cb"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "facb8e7671e66c6b30c7c75e72fc7d4b6b35a8dd33eb589e8317759f7ead53d6b3fa2da14ea1d9bc09cd991f5e540bcd4cded285a012dbcdaca7edb3883a9748"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "8"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/10.04",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "3240375c7b56cd3fa8d4755d644c456b61cd40a5fcf084494b04dc0555ffc88437ff566decfc3751b0e97e4176d1ef5e2a4aabded79268d834d3b351bc8d84f5"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.04"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "eb6ddc33a20fe01a38f7f4003941866debb48e2e"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "47db96d66ed98be7db6fb97edd3552b4c436e01c27c34eaf26a8b87eaf548074"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "0f835a563b341d6a8340b1c8315a984a"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/mac_os_x/10.11",
+          "name" : "push-jobs-client-2.1.0-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.11"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "77fd61f945ce59aa869955a134fd80ddd7754cc1d5d9a15fc43ec15d163bf07d"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "b3cf4f5d4626f879cd59b8c4a3a017ce017b07fc"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "65896d961f4c170c99735286dcd44ec6"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "d2b69aa1342f5b8fd9887473a1cfb01130cd5dfabf08acb5a8dfb90ad0f9012905c59e3ce3ca32cc7fb6ca7f29c2b41a3d35c83072964330648cc793345e6f1c"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/6",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "fd4d5116263515ac6887cbd77ee731fa5e784d37bd511fece09716bbaefdf2ea83b88c2845eaa5ebbf79196820debc76a2316c460cf51e099e5773f1ce2f8817"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "349b704e7dbf7060e214d78f372346dc"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f61067ba5ac78bf2e8c002782767c42fb4fde317"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd1e338eb4ba9a4b84cb04e2b01c34f797bbc8eef88d9cd1c9bbe80dff501ba9"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/10.04",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "36b294b739cbc9f55387dd322281c41096ce9a72"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "c4105d75087f36c81826fd10e981eaee"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "89ed9c4d0ea8265f60cb94fd66c8fa5fb3f817f9c5884aa3180b56779aba71a303c2e7a2357f68f96369e3d00a990ad28ec01dc1df1124724837631d50331a9d"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "385cbee101c04c612532d4cafea2e8c08b8ae98183e31080407077840f134fd6"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.04"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/7",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f61067ba5ac78bf2e8c002782767c42fb4fde317"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "349b704e7dbf7060e214d78f372346dc"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd1e338eb4ba9a4b84cb04e2b01c34f797bbc8eef88d9cd1c9bbe80dff501ba9"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "fd4d5116263515ac6887cbd77ee731fa5e784d37bd511fece09716bbaefdf2ea83b88c2845eaa5ebbf79196820debc76a2316c460cf51e099e5773f1ce2f8817"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/14.04",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "c4105d75087f36c81826fd10e981eaee"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "36b294b739cbc9f55387dd322281c41096ce9a72"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "385cbee101c04c612532d4cafea2e8c08b8ae98183e31080407077840f134fd6"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "89ed9c4d0ea8265f60cb94fd66c8fa5fb3f817f9c5884aa3180b56779aba71a303c2e7a2357f68f96369e3d00a990ad28ec01dc1df1124724837631d50331a9d"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/5",
+          "name" : "push-jobs-client-2.1.0-1.el5.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "19b6b9f136b74302677590b23af74903"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "e1b1d4125e67b7149e1458ff68af492975107779696b89d2f0462b5c9d88ff11"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f327b52b2430dadd0fb1a07fefdadfb52316c890"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "b0ee9c61a77e82134d181a8f6b127214e588db98f25d44959a6c2464a73ac8c2b951e93f38349096dec72514343f93864231aa79c4f8394aeaae1cc681283b90"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "delivery.sha"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/mac_os_x/10.10",
+          "name" : "push-jobs-client-2.1.0-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "65896d961f4c170c99735286dcd44ec6"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "77fd61f945ce59aa869955a134fd80ddd7754cc1d5d9a15fc43ec15d163bf07d"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "d2b69aa1342f5b8fd9887473a1cfb01130cd5dfabf08acb5a8dfb90ad0f9012905c59e3ce3ca32cc7fb6ca7f29c2b41a3d35c83072964330648cc793345e6f1c"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "b3cf4f5d4626f879cd59b8c4a3a017ce017b07fc"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.10"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/6",
+          "name" : "push-jobs-client-2.1.0-1.el6.i386.rpm",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b90b9122bc07d0af352c0feebb14f4fb10dda14123080887152b0bd6d18d3d78"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "d2b6b827db576bfc6b3bf2c08ab9966c"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "61d3465de234aa9a788e1cb8736e23190e873f1c"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "deb8de984e471dea7ac415af2df6758b89ad38112bd85d30575786c364e0b07219633298c6d56a1402bff62973261966a39b9af51bed74c34aff987122d419cb"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/windows/2012r2",
+          "name" : "push-jobs-client-2.1.0-1-x86.msi",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012r2"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "21c8614579593dd57c820fc06ad7fa09"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a14a29b001c1e6d21c8d15192071f4854ce4184b"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "b3c02a1b2a89d2a351b8608218cf13a2c9d59d4073ef2f35e13f6d815d65bd94e3ccbf3fbb18f504b6c56eb37402558e228da3f4e48d82d8a81c801b81c32699"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d86b37a67a12b0b91a1c25d4cdc0667721d80b74f5cd1891ff97597129b76b59"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/7",
+          "name" : "push-jobs-client-2.1.0-1.el7.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "11a6236da4b571f103d8aa4af1dda25c"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "3b06ab32342bee29868f5abf5951e59315256cd253b9659da74b9f5fb219f4312d71d4a1188378796a3c628a7398240fbf75704ac5cc7548dc2b3bcf1428b153"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "19ea3b78a9703c74592db84388b2b22786a41a17"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "eacf6ad2c318dcfee47a210087dbab908ab02b1ec6793506464f82d31895f2f8"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 23,
+          "total" : 23
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:44 GMT
+- request:
+    method: get
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/build/push-jobs-client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:49 GMT
+      Content-Type:
+      - application/vnd.org.jfrog.build.BuildsByName+json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "buildsNumbers" : [ {
+            "uri" : "/2.1.0+20160703080116",
+            "started" : "2016-07-03T08:35:43.637+0000"
+          }, {
+            "uri" : "/2.1.0+20160612080112",
+            "started" : "2016-06-12T08:43:34.559+0000"
+          }, {
+            "uri" : "/2.1.0+20160701080111",
+            "started" : "2016-07-01T08:36:27.055+0000"
+          }, {
+            "uri" : "/2.1.0+20160624080109",
+            "started" : "2016-06-24T08:35:45.713+0000"
+          }, {
+            "uri" : "/1.3.4",
+            "started" : "2015-11-04T03:14:39.286+0000"
+          }, {
+            "uri" : "/2.1.0+20160623080108",
+            "started" : "2016-06-23T08:35:30.989+0000"
+          }, {
+            "uri" : "/2.1.0+20160705080108",
+            "started" : "2016-07-05T08:35:48.858+0000"
+          }, {
+            "uri" : "/2.1.0+20160630080111",
+            "started" : "2016-06-30T08:35:46.574+0000"
+          }, {
+            "uri" : "/2.1.0+20160610080110",
+            "started" : "2016-06-10T08:43:53.665+0000"
+          }, {
+            "uri" : "/2.1.0",
+            "started" : "2016-05-17T19:09:27.709+0000"
+          }, {
+            "uri" : "/2.1.0+20160611080110",
+            "started" : "2016-06-11T08:43:37.191+0000"
+          }, {
+            "uri" : "/1.3.3",
+            "started" : "2015-09-18T00:58:22.412+0000"
+          }, {
+            "uri" : "/2.1.0+20160613080109",
+            "started" : "2016-06-13T08:43:24.459+0000"
+          }, {
+            "uri" : "/2.1.0+20160618080111",
+            "started" : "2016-06-18T08:35:41.022+0000"
+          }, {
+            "uri" : "/2.1.0+20160607080110",
+            "started" : "2016-06-07T08:58:07.616+0000"
+          }, {
+            "uri" : "/2.1.0+20160622080111",
+            "started" : "2016-06-22T08:35:39.315+0000"
+          }, {
+            "uri" : "/2.1.0+20160620080109",
+            "started" : "2016-06-20T08:35:47.564+0000"
+          }, {
+            "uri" : "/2.1.0+20160702080110",
+            "started" : "2016-07-02T08:35:35.852+0000"
+          }, {
+            "uri" : "/2.1.0+20160704080112",
+            "started" : "2016-07-04T08:35:45.130+0000"
+          }, {
+            "uri" : "/2.1.0+20160617080110",
+            "started" : "2016-06-17T08:45:35.598+0000"
+          } ],
+          "uri" : "http://artifactory.chef.co/api/build/push-jobs-client"
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:44 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160705080108"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:45 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160704080112"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:45 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160703080116"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:45 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160702080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:51 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:46 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160701080111"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:51 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:46 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160630080111"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:51 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:46 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160624080109"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:52 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:47 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160623080108"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:52 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:47 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160622080111"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:53 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:48 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160620080109"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:53 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:48 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160618080111"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:53 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:48 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160617080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:49 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160613080109"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:49 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160612080112"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:55 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:49 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160611080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:55 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:50 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160610080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:55 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:50 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160607080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:51 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/6",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha256",
+            "value" : "8948f700750729746d23692251e41d7694d6df379bafca324743d246cb7ed054"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "198c911b61253e5c93489bf1007ac2cb"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "facb8e7671e66c6b30c7c75e72fc7d4b6b35a8dd33eb589e8317759f7ead53d6b3fa2da14ea1d9bc09cd991f5e540bcd4cded285a012dbcdaca7edb3883a9748"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "d5affb4c8276fb435e901646dce62f40cc2c6efb"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/5",
+          "name" : "push-jobs-client-2.1.0-1.el5.i386.rpm",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "7190c62f9f8a23fdd2094a9d594e7bd94df8802e"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "171abb92f4db585c08a823c3966dd2d6c681b3b50ae03832c9ccaa8bb3829bc207977230940c16cfda14ae9111612cc0f524fd908b8004ec98bd24c1f67025ab"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "2d9d96c9001d6848cfd6e8b9e0f76e3df03008c4e74606a54346a3f2db2c80e0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "05df6f6ecff4af4e3a1890730b8e1a8b"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/12.04",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "89ed9c4d0ea8265f60cb94fd66c8fa5fb3f817f9c5884aa3180b56779aba71a303c2e7a2357f68f96369e3d00a990ad28ec01dc1df1124724837631d50331a9d"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "385cbee101c04c612532d4cafea2e8c08b8ae98183e31080407077840f134fd6"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "36b294b739cbc9f55387dd322281c41096ce9a72"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "c4105d75087f36c81826fd10e981eaee"
+          }, {
+            "key" : "delivery.sha"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/mac_os_x/10.9",
+          "name" : "push-jobs-client-2.1.0-1.dmg",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "65896d961f4c170c99735286dcd44ec6"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "d2b69aa1342f5b8fd9887473a1cfb01130cd5dfabf08acb5a8dfb90ad0f9012905c59e3ce3ca32cc7fb6ca7f29c2b41a3d35c83072964330648cc793345e6f1c"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.9"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "b3cf4f5d4626f879cd59b8c4a3a017ce017b07fc"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "77fd61f945ce59aa869955a134fd80ddd7754cc1d5d9a15fc43ec15d163bf07d"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/12.04",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "0f835a563b341d6a8340b1c8315a984a"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "47db96d66ed98be7db6fb97edd3552b4c436e01c27c34eaf26a8b87eaf548074"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "eb6ddc33a20fe01a38f7f4003941866debb48e2e"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "3240375c7b56cd3fa8d4755d644c456b61cd40a5fcf084494b04dc0555ffc88437ff566decfc3751b0e97e4176d1ef5e2a4aabded79268d834d3b351bc8d84f5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/8",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.platform_version",
+            "value" : "8"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f61067ba5ac78bf2e8c002782767c42fb4fde317"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd1e338eb4ba9a4b84cb04e2b01c34f797bbc8eef88d9cd1c9bbe80dff501ba9"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "349b704e7dbf7060e214d78f372346dc"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "fd4d5116263515ac6887cbd77ee731fa5e784d37bd511fece09716bbaefdf2ea83b88c2845eaa5ebbf79196820debc76a2316c460cf51e099e5773f1ce2f8817"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/6",
+          "name" : "push-jobs-client-2.1.0-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "abd157603b243b66ce23712ab66b3cf7"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "a3ac2f0033820310ff4f3fb3a287ad1afe1f57ae410cdc220aa89ed15a1c4a432d17a8bcc0b838c936ff6ffef62faed13e75522275144908272500918f2d67a4"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "913088585c9cf7319eaab4127d47cc173ebf4bf8"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "1eb8688e906697f2ad78eec8ca6fe0bbf137477fa09f2f2c90f8498ed7a67979"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/7",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "d5affb4c8276fb435e901646dce62f40cc2c6efb"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "8948f700750729746d23692251e41d7694d6df379bafca324743d246cb7ed054"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "198c911b61253e5c93489bf1007ac2cb"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "facb8e7671e66c6b30c7c75e72fc7d4b6b35a8dd33eb589e8317759f7ead53d6b3fa2da14ea1d9bc09cd991f5e540bcd4cded285a012dbcdaca7edb3883a9748"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/14.04",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "eb6ddc33a20fe01a38f7f4003941866debb48e2e"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "3240375c7b56cd3fa8d4755d644c456b61cd40a5fcf084494b04dc0555ffc88437ff566decfc3751b0e97e4176d1ef5e2a4aabded79268d834d3b351bc8d84f5"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "47db96d66ed98be7db6fb97edd3552b4c436e01c27c34eaf26a8b87eaf548074"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "0f835a563b341d6a8340b1c8315a984a"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/windows/2012",
+          "name" : "push-jobs-client-2.1.0-1-x86.msi",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "21c8614579593dd57c820fc06ad7fa09"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d86b37a67a12b0b91a1c25d4cdc0667721d80b74f5cd1891ff97597129b76b59"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "b3c02a1b2a89d2a351b8608218cf13a2c9d59d4073ef2f35e13f6d815d65bd94e3ccbf3fbb18f504b6c56eb37402558e228da3f4e48d82d8a81c801b81c32699"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a14a29b001c1e6d21c8d15192071f4854ce4184b"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/windows/2008r2",
+          "name" : "push-jobs-client-2.1.0-1-x86.msi",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "b3c02a1b2a89d2a351b8608218cf13a2c9d59d4073ef2f35e13f6d815d65bd94e3ccbf3fbb18f504b6c56eb37402558e228da3f4e48d82d8a81c801b81c32699"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "21c8614579593dd57c820fc06ad7fa09"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a14a29b001c1e6d21c8d15192071f4854ce4184b"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2008r2"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d86b37a67a12b0b91a1c25d4cdc0667721d80b74f5cd1891ff97597129b76b59"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/8",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "8948f700750729746d23692251e41d7694d6df379bafca324743d246cb7ed054"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "d5affb4c8276fb435e901646dce62f40cc2c6efb"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "198c911b61253e5c93489bf1007ac2cb"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "facb8e7671e66c6b30c7c75e72fc7d4b6b35a8dd33eb589e8317759f7ead53d6b3fa2da14ea1d9bc09cd991f5e540bcd4cded285a012dbcdaca7edb3883a9748"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "8"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/10.04",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "3240375c7b56cd3fa8d4755d644c456b61cd40a5fcf084494b04dc0555ffc88437ff566decfc3751b0e97e4176d1ef5e2a4aabded79268d834d3b351bc8d84f5"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.04"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "eb6ddc33a20fe01a38f7f4003941866debb48e2e"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "47db96d66ed98be7db6fb97edd3552b4c436e01c27c34eaf26a8b87eaf548074"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "0f835a563b341d6a8340b1c8315a984a"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/mac_os_x/10.11",
+          "name" : "push-jobs-client-2.1.0-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.11"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "77fd61f945ce59aa869955a134fd80ddd7754cc1d5d9a15fc43ec15d163bf07d"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "b3cf4f5d4626f879cd59b8c4a3a017ce017b07fc"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "65896d961f4c170c99735286dcd44ec6"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "d2b69aa1342f5b8fd9887473a1cfb01130cd5dfabf08acb5a8dfb90ad0f9012905c59e3ce3ca32cc7fb6ca7f29c2b41a3d35c83072964330648cc793345e6f1c"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/6",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "fd4d5116263515ac6887cbd77ee731fa5e784d37bd511fece09716bbaefdf2ea83b88c2845eaa5ebbf79196820debc76a2316c460cf51e099e5773f1ce2f8817"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "349b704e7dbf7060e214d78f372346dc"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f61067ba5ac78bf2e8c002782767c42fb4fde317"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd1e338eb4ba9a4b84cb04e2b01c34f797bbc8eef88d9cd1c9bbe80dff501ba9"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/10.04",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "36b294b739cbc9f55387dd322281c41096ce9a72"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "c4105d75087f36c81826fd10e981eaee"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "89ed9c4d0ea8265f60cb94fd66c8fa5fb3f817f9c5884aa3180b56779aba71a303c2e7a2357f68f96369e3d00a990ad28ec01dc1df1124724837631d50331a9d"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "385cbee101c04c612532d4cafea2e8c08b8ae98183e31080407077840f134fd6"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.04"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/7",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f61067ba5ac78bf2e8c002782767c42fb4fde317"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "349b704e7dbf7060e214d78f372346dc"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd1e338eb4ba9a4b84cb04e2b01c34f797bbc8eef88d9cd1c9bbe80dff501ba9"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "fd4d5116263515ac6887cbd77ee731fa5e784d37bd511fece09716bbaefdf2ea83b88c2845eaa5ebbf79196820debc76a2316c460cf51e099e5773f1ce2f8817"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/14.04",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "c4105d75087f36c81826fd10e981eaee"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "36b294b739cbc9f55387dd322281c41096ce9a72"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "385cbee101c04c612532d4cafea2e8c08b8ae98183e31080407077840f134fd6"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "89ed9c4d0ea8265f60cb94fd66c8fa5fb3f817f9c5884aa3180b56779aba71a303c2e7a2357f68f96369e3d00a990ad28ec01dc1df1124724837631d50331a9d"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/5",
+          "name" : "push-jobs-client-2.1.0-1.el5.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "19b6b9f136b74302677590b23af74903"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "e1b1d4125e67b7149e1458ff68af492975107779696b89d2f0462b5c9d88ff11"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f327b52b2430dadd0fb1a07fefdadfb52316c890"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "b0ee9c61a77e82134d181a8f6b127214e588db98f25d44959a6c2464a73ac8c2b951e93f38349096dec72514343f93864231aa79c4f8394aeaae1cc681283b90"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "delivery.sha"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/mac_os_x/10.10",
+          "name" : "push-jobs-client-2.1.0-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "65896d961f4c170c99735286dcd44ec6"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "77fd61f945ce59aa869955a134fd80ddd7754cc1d5d9a15fc43ec15d163bf07d"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "d2b69aa1342f5b8fd9887473a1cfb01130cd5dfabf08acb5a8dfb90ad0f9012905c59e3ce3ca32cc7fb6ca7f29c2b41a3d35c83072964330648cc793345e6f1c"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "b3cf4f5d4626f879cd59b8c4a3a017ce017b07fc"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.10"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/6",
+          "name" : "push-jobs-client-2.1.0-1.el6.i386.rpm",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b90b9122bc07d0af352c0feebb14f4fb10dda14123080887152b0bd6d18d3d78"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "d2b6b827db576bfc6b3bf2c08ab9966c"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "61d3465de234aa9a788e1cb8736e23190e873f1c"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "deb8de984e471dea7ac415af2df6758b89ad38112bd85d30575786c364e0b07219633298c6d56a1402bff62973261966a39b9af51bed74c34aff987122d419cb"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/windows/2012r2",
+          "name" : "push-jobs-client-2.1.0-1-x86.msi",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012r2"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "21c8614579593dd57c820fc06ad7fa09"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a14a29b001c1e6d21c8d15192071f4854ce4184b"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "b3c02a1b2a89d2a351b8608218cf13a2c9d59d4073ef2f35e13f6d815d65bd94e3ccbf3fbb18f504b6c56eb37402558e228da3f4e48d82d8a81c801b81c32699"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d86b37a67a12b0b91a1c25d4cdc0667721d80b74f5cd1891ff97597129b76b59"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/7",
+          "name" : "push-jobs-client-2.1.0-1.el7.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "11a6236da4b571f103d8aa4af1dda25c"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "3b06ab32342bee29868f5abf5951e59315256cd253b9659da74b9f5fb219f4312d71d4a1188378796a3c628a7398240fbf75704ac5cc7548dc2b3bcf1428b153"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "19ea3b78a9703c74592db84388b2b22786a41a17"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "eacf6ad2c318dcfee47a210087dbab908ab02b1ec6793506464f82d31895f2f8"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 23,
+          "total" : 23
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:51 GMT
+- request:
+    method: get
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/build/push-jobs-client
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:56 GMT
+      Content-Type:
+      - application/vnd.org.jfrog.build.BuildsByName+json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "buildsNumbers" : [ {
+            "uri" : "/2.1.0+20160703080116",
+            "started" : "2016-07-03T08:35:43.637+0000"
+          }, {
+            "uri" : "/2.1.0+20160612080112",
+            "started" : "2016-06-12T08:43:34.559+0000"
+          }, {
+            "uri" : "/2.1.0+20160701080111",
+            "started" : "2016-07-01T08:36:27.055+0000"
+          }, {
+            "uri" : "/2.1.0+20160624080109",
+            "started" : "2016-06-24T08:35:45.713+0000"
+          }, {
+            "uri" : "/1.3.4",
+            "started" : "2015-11-04T03:14:39.286+0000"
+          }, {
+            "uri" : "/2.1.0+20160623080108",
+            "started" : "2016-06-23T08:35:30.989+0000"
+          }, {
+            "uri" : "/2.1.0+20160705080108",
+            "started" : "2016-07-05T08:35:48.858+0000"
+          }, {
+            "uri" : "/2.1.0+20160630080111",
+            "started" : "2016-06-30T08:35:46.574+0000"
+          }, {
+            "uri" : "/2.1.0+20160610080110",
+            "started" : "2016-06-10T08:43:53.665+0000"
+          }, {
+            "uri" : "/2.1.0",
+            "started" : "2016-05-17T19:09:27.709+0000"
+          }, {
+            "uri" : "/2.1.0+20160611080110",
+            "started" : "2016-06-11T08:43:37.191+0000"
+          }, {
+            "uri" : "/1.3.3",
+            "started" : "2015-09-18T00:58:22.412+0000"
+          }, {
+            "uri" : "/2.1.0+20160613080109",
+            "started" : "2016-06-13T08:43:24.459+0000"
+          }, {
+            "uri" : "/2.1.0+20160618080111",
+            "started" : "2016-06-18T08:35:41.022+0000"
+          }, {
+            "uri" : "/2.1.0+20160607080110",
+            "started" : "2016-06-07T08:58:07.616+0000"
+          }, {
+            "uri" : "/2.1.0+20160622080111",
+            "started" : "2016-06-22T08:35:39.315+0000"
+          }, {
+            "uri" : "/2.1.0+20160620080109",
+            "started" : "2016-06-20T08:35:47.564+0000"
+          }, {
+            "uri" : "/2.1.0+20160702080110",
+            "started" : "2016-07-02T08:35:35.852+0000"
+          }, {
+            "uri" : "/2.1.0+20160704080112",
+            "started" : "2016-07-04T08:35:45.130+0000"
+          }, {
+            "uri" : "/2.1.0+20160617080110",
+            "started" : "2016-06-17T08:45:35.598+0000"
+          } ],
+          "uri" : "http://artifactory.chef.co/api/build/push-jobs-client"
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:51 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160705080108"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:57 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:52 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160704080112"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:57 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:52 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160703080116"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:57 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:52 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160702080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:58 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:53 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160701080111"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:58 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:53 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160630080111"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:53 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160624080109"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:54 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160623080108"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:54 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160622080111"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:00 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:55 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160620080109"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:00 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:55 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160618080111"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:00 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:55 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160617080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:56 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160613080109"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:56 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160612080112"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:56 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160611080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:57 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160610080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:57 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0+20160607080110"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:03 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:57 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "push-jobs-client"},
+          {"@omnibus.version": "2.1.0"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:12:03 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/6",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha256",
+            "value" : "8948f700750729746d23692251e41d7694d6df379bafca324743d246cb7ed054"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "198c911b61253e5c93489bf1007ac2cb"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "facb8e7671e66c6b30c7c75e72fc7d4b6b35a8dd33eb589e8317759f7ead53d6b3fa2da14ea1d9bc09cd991f5e540bcd4cded285a012dbcdaca7edb3883a9748"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "d5affb4c8276fb435e901646dce62f40cc2c6efb"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/5",
+          "name" : "push-jobs-client-2.1.0-1.el5.i386.rpm",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "7190c62f9f8a23fdd2094a9d594e7bd94df8802e"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "171abb92f4db585c08a823c3966dd2d6c681b3b50ae03832c9ccaa8bb3829bc207977230940c16cfda14ae9111612cc0f524fd908b8004ec98bd24c1f67025ab"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "2d9d96c9001d6848cfd6e8b9e0f76e3df03008c4e74606a54346a3f2db2c80e0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "05df6f6ecff4af4e3a1890730b8e1a8b"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/12.04",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "89ed9c4d0ea8265f60cb94fd66c8fa5fb3f817f9c5884aa3180b56779aba71a303c2e7a2357f68f96369e3d00a990ad28ec01dc1df1124724837631d50331a9d"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "385cbee101c04c612532d4cafea2e8c08b8ae98183e31080407077840f134fd6"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "36b294b739cbc9f55387dd322281c41096ce9a72"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "c4105d75087f36c81826fd10e981eaee"
+          }, {
+            "key" : "delivery.sha"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/mac_os_x/10.9",
+          "name" : "push-jobs-client-2.1.0-1.dmg",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "65896d961f4c170c99735286dcd44ec6"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "d2b69aa1342f5b8fd9887473a1cfb01130cd5dfabf08acb5a8dfb90ad0f9012905c59e3ce3ca32cc7fb6ca7f29c2b41a3d35c83072964330648cc793345e6f1c"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.9"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "b3cf4f5d4626f879cd59b8c4a3a017ce017b07fc"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "77fd61f945ce59aa869955a134fd80ddd7754cc1d5d9a15fc43ec15d163bf07d"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/12.04",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "0f835a563b341d6a8340b1c8315a984a"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "47db96d66ed98be7db6fb97edd3552b4c436e01c27c34eaf26a8b87eaf548074"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "eb6ddc33a20fe01a38f7f4003941866debb48e2e"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "3240375c7b56cd3fa8d4755d644c456b61cd40a5fcf084494b04dc0555ffc88437ff566decfc3751b0e97e4176d1ef5e2a4aabded79268d834d3b351bc8d84f5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/8",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.platform_version",
+            "value" : "8"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f61067ba5ac78bf2e8c002782767c42fb4fde317"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd1e338eb4ba9a4b84cb04e2b01c34f797bbc8eef88d9cd1c9bbe80dff501ba9"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "349b704e7dbf7060e214d78f372346dc"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "fd4d5116263515ac6887cbd77ee731fa5e784d37bd511fece09716bbaefdf2ea83b88c2845eaa5ebbf79196820debc76a2316c460cf51e099e5773f1ce2f8817"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/6",
+          "name" : "push-jobs-client-2.1.0-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "abd157603b243b66ce23712ab66b3cf7"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "a3ac2f0033820310ff4f3fb3a287ad1afe1f57ae410cdc220aa89ed15a1c4a432d17a8bcc0b838c936ff6ffef62faed13e75522275144908272500918f2d67a4"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "913088585c9cf7319eaab4127d47cc173ebf4bf8"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "1eb8688e906697f2ad78eec8ca6fe0bbf137477fa09f2f2c90f8498ed7a67979"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/7",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "d5affb4c8276fb435e901646dce62f40cc2c6efb"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "8948f700750729746d23692251e41d7694d6df379bafca324743d246cb7ed054"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "198c911b61253e5c93489bf1007ac2cb"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "facb8e7671e66c6b30c7c75e72fc7d4b6b35a8dd33eb589e8317759f7ead53d6b3fa2da14ea1d9bc09cd991f5e540bcd4cded285a012dbcdaca7edb3883a9748"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/14.04",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "eb6ddc33a20fe01a38f7f4003941866debb48e2e"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "3240375c7b56cd3fa8d4755d644c456b61cd40a5fcf084494b04dc0555ffc88437ff566decfc3751b0e97e4176d1ef5e2a4aabded79268d834d3b351bc8d84f5"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "47db96d66ed98be7db6fb97edd3552b4c436e01c27c34eaf26a8b87eaf548074"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "0f835a563b341d6a8340b1c8315a984a"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/windows/2012",
+          "name" : "push-jobs-client-2.1.0-1-x86.msi",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "21c8614579593dd57c820fc06ad7fa09"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d86b37a67a12b0b91a1c25d4cdc0667721d80b74f5cd1891ff97597129b76b59"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "b3c02a1b2a89d2a351b8608218cf13a2c9d59d4073ef2f35e13f6d815d65bd94e3ccbf3fbb18f504b6c56eb37402558e228da3f4e48d82d8a81c801b81c32699"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a14a29b001c1e6d21c8d15192071f4854ce4184b"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/windows/2008r2",
+          "name" : "push-jobs-client-2.1.0-1-x86.msi",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "b3c02a1b2a89d2a351b8608218cf13a2c9d59d4073ef2f35e13f6d815d65bd94e3ccbf3fbb18f504b6c56eb37402558e228da3f4e48d82d8a81c801b81c32699"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "21c8614579593dd57c820fc06ad7fa09"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a14a29b001c1e6d21c8d15192071f4854ce4184b"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2008r2"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d86b37a67a12b0b91a1c25d4cdc0667721d80b74f5cd1891ff97597129b76b59"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/8",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "8948f700750729746d23692251e41d7694d6df379bafca324743d246cb7ed054"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "d5affb4c8276fb435e901646dce62f40cc2c6efb"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "198c911b61253e5c93489bf1007ac2cb"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "facb8e7671e66c6b30c7c75e72fc7d4b6b35a8dd33eb589e8317759f7ead53d6b3fa2da14ea1d9bc09cd991f5e540bcd4cded285a012dbcdaca7edb3883a9748"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "8"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/10.04",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "3240375c7b56cd3fa8d4755d644c456b61cd40a5fcf084494b04dc0555ffc88437ff566decfc3751b0e97e4176d1ef5e2a4aabded79268d834d3b351bc8d84f5"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.04"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "eb6ddc33a20fe01a38f7f4003941866debb48e2e"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "47db96d66ed98be7db6fb97edd3552b4c436e01c27c34eaf26a8b87eaf548074"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "0f835a563b341d6a8340b1c8315a984a"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/mac_os_x/10.11",
+          "name" : "push-jobs-client-2.1.0-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.11"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "77fd61f945ce59aa869955a134fd80ddd7754cc1d5d9a15fc43ec15d163bf07d"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "b3cf4f5d4626f879cd59b8c4a3a017ce017b07fc"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "65896d961f4c170c99735286dcd44ec6"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "d2b69aa1342f5b8fd9887473a1cfb01130cd5dfabf08acb5a8dfb90ad0f9012905c59e3ce3ca32cc7fb6ca7f29c2b41a3d35c83072964330648cc793345e6f1c"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/6",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "fd4d5116263515ac6887cbd77ee731fa5e784d37bd511fece09716bbaefdf2ea83b88c2845eaa5ebbf79196820debc76a2316c460cf51e099e5773f1ce2f8817"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "349b704e7dbf7060e214d78f372346dc"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f61067ba5ac78bf2e8c002782767c42fb4fde317"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd1e338eb4ba9a4b84cb04e2b01c34f797bbc8eef88d9cd1c9bbe80dff501ba9"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/10.04",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "36b294b739cbc9f55387dd322281c41096ce9a72"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "c4105d75087f36c81826fd10e981eaee"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "89ed9c4d0ea8265f60cb94fd66c8fa5fb3f817f9c5884aa3180b56779aba71a303c2e7a2357f68f96369e3d00a990ad28ec01dc1df1124724837631d50331a9d"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "385cbee101c04c612532d4cafea2e8c08b8ae98183e31080407077840f134fd6"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.04"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/debian/7",
+          "name" : "push-jobs-client_2.1.0-1_i386.deb",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f61067ba5ac78bf2e8c002782767c42fb4fde317"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "349b704e7dbf7060e214d78f372346dc"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd1e338eb4ba9a4b84cb04e2b01c34f797bbc8eef88d9cd1c9bbe80dff501ba9"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "fd4d5116263515ac6887cbd77ee731fa5e784d37bd511fece09716bbaefdf2ea83b88c2845eaa5ebbf79196820debc76a2316c460cf51e099e5773f1ce2f8817"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/ubuntu/14.04",
+          "name" : "push-jobs-client_2.1.0-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "c4105d75087f36c81826fd10e981eaee"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "36b294b739cbc9f55387dd322281c41096ce9a72"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "385cbee101c04c612532d4cafea2e8c08b8ae98183e31080407077840f134fd6"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "89ed9c4d0ea8265f60cb94fd66c8fa5fb3f817f9c5884aa3180b56779aba71a303c2e7a2357f68f96369e3d00a990ad28ec01dc1df1124724837631d50331a9d"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/5",
+          "name" : "push-jobs-client-2.1.0-1.el5.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "19b6b9f136b74302677590b23af74903"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "e1b1d4125e67b7149e1458ff68af492975107779696b89d2f0462b5c9d88ff11"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f327b52b2430dadd0fb1a07fefdadfb52316c890"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "b0ee9c61a77e82134d181a8f6b127214e588db98f25d44959a6c2464a73ac8c2b951e93f38349096dec72514343f93864231aa79c4f8394aeaae1cc681283b90"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "delivery.sha"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/mac_os_x/10.10",
+          "name" : "push-jobs-client-2.1.0-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "65896d961f4c170c99735286dcd44ec6"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "77fd61f945ce59aa869955a134fd80ddd7754cc1d5d9a15fc43ec15d163bf07d"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "d2b69aa1342f5b8fd9887473a1cfb01130cd5dfabf08acb5a8dfb90ad0f9012905c59e3ce3ca32cc7fb6ca7f29c2b41a3d35c83072964330648cc793345e6f1c"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "b3cf4f5d4626f879cd59b8c4a3a017ce017b07fc"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.10"
+          }, {
+            "key" : "delivery.change"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/6",
+          "name" : "push-jobs-client-2.1.0-1.el6.i386.rpm",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b90b9122bc07d0af352c0feebb14f4fb10dda14123080887152b0bd6d18d3d78"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "d2b6b827db576bfc6b3bf2c08ab9966c"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "61d3465de234aa9a788e1cb8736e23190e873f1c"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "deb8de984e471dea7ac415af2df6758b89ad38112bd85d30575786c364e0b07219633298c6d56a1402bff62973261966a39b9af51bed74c34aff987122d419cb"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/windows/2012r2",
+          "name" : "push-jobs-client-2.1.0-1-x86.msi",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012r2"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "21c8614579593dd57c820fc06ad7fa09"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a14a29b001c1e6d21c8d15192071f4854ce4184b"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "b3c02a1b2a89d2a351b8608218cf13a2c9d59d4073ef2f35e13f6d815d65bd94e3ccbf3fbb18f504b6c56eb37402558e228da3f4e48d82d8a81c801b81c32699"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d86b37a67a12b0b91a1c25d4cdc0667721d80b74f5cd1891ff97597129b76b59"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/push-jobs-client/2.1.0/el/7",
+          "name" : "push-jobs-client-2.1.0-1.el7.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "11a6236da4b571f103d8aa4af1dda25c"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "2.1.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "3b06ab32342bee29868f5abf5951e59315256cd253b9659da74b9f5fb219f4312d71d4a1188378796a3c628a7398240fbf75704ac5cc7548dc2b3bcf1428b153"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "19ea3b78a9703c74592db84388b2b22786a41a17"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "2.1.0"
+          }, {
+            "key" : "build.name",
+            "value" : "push-jobs-client"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "eacf6ad2c318dcfee47a210087dbab908ab02b1ec6793506464f82d31895f2f8"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 23,
+          "total" : 23
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_Artifactory_all_channels/for_push_jobs_client/for_version_1_1_5/uses_omnibus_project_name.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_Artifactory_all_channels/for_push_jobs_client/for_version_1_1_5/uses_omnibus_project_name.yml
@@ -1,0 +1,747 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "opscode-push-jobs-client"},
+          {"@omnibus.version": "1.1.5"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:42 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/ubuntu/10.04",
+          "name" : "opscode-push-jobs-client_1.1.5-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.04"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "0a8f5069b7281f5acb800290d2e18b766864d46597fc84548f14a17a5b437426"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "86bd4997cd666f73ad80c3927c750a8f4577e9e573cc5db645d9e1cba73cb35d2f57342711b3a829472eff5307c23b6a258bcec485c504c482f69174a5d94791"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "d319f63207ac51f78a58151e1c493ceb"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "7801746fabcf838c0396496b4826edbc8ec5a6e5"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/ubuntu/10.04",
+          "name" : "opscode-push-jobs-client_1.1.5-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "3f1de1454eaef5a9877c94f33982b381"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.04"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "1b1435aad98042d8b224181f45c2f5911aed8517f7a5b1429176c59bba807586"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "833c6201c3258e3fda27bf536a2f683c1d192ee0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "f87b4626997cb47c2ba73748d0d34eaff58f6138022a066b5dd24c7cd58f49cc44b633aa0a7269aa1ae59d4d67ebdccdef26f53684ba0f2cff93b695f167f26b"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/ubuntu/12.04",
+          "name" : "opscode-push-jobs-client_1.1.5-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "cf74fd95955739cc9ff70eebcbe59809"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d7b40ebb18c7c7dbc32322c9bcd721279e707fd1bee3609a37055838afbf67ea"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "c38e3a3f78e9b374268ef2179c19eb5116b69928014b905ea973890fabc078ddfada30c2a75df8a98a9abf72c6466b9ebc74abbb04285116c6f07868833dda53"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "d659c06c72397ed2bc6cd88488349857f1958538"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/ubuntu/12.04",
+          "name" : "opscode-push-jobs-client_1.1.5-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ae8904b0a58e05e6eb15f451211a9afff086fb008459d3abb5d6b6ac3a88617c56f0769d10179e662d2b25b17eb4f2c333a06121cbc36ef260b53be520410f63"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "07aed8fc0422b05be7f8362efde4716a70c0b312"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "a5df71751991e9a03def52247d0ac050"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "f2ab544c23507e1bfd5374da14161014cb45fae4d3f1acfe0de5712b5d7472db"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/windows/2008r2",
+          "name" : "opscode-push-jobs-client-windows-1.1.5-1.windows.msi",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "411520e6a2e3038cd018ffacee0e76e37e7badd1aa84de03f5469c19e8d6c576"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "daf4f5c35b9b86bd5aab5200bc0f22c0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2008r2"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "38b43b5895e44c4c64c5ae19337f7bc918ffdd2b"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "f079b97aae0589ffda6c60a2f6d71a9a4cdc988380e5f0947bb390f87122923b57db4bb75c6422a7c3f772fce70487c013b408942890ac7648f4b9f39b12a0f2"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/el/5",
+          "name" : "opscode-push-jobs-client-1.1.5-1.el5.i686.rpm",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "33e9dbcca06b3806ce99774644e78003"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "2a6f46880229234776d94f926af241547817c5190cc7340f4b5fa3383a236af7"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "8652cb8afc3670c96e94892bbd232dd6d8e302fe"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "018b49bf38fd43386c9d59bbf33ef1eff07d32133bf8d432af05a47031da456a1c0418a02d31581318a3fc1e86d8aac617b55f397660309add6bd66d25e76116"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/el/5",
+          "name" : "opscode-push-jobs-client-1.1.5-1.el5.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.sha256",
+            "value" : "98b80e02a989d2a7dd7eda29a5954f319648c8a11576aec33012661d7c9455c3"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "e1f000edb1931b3d3af33c2ae04fb42a09d45d9ae0ada1f986dc8b8bf7d644067359b68d5f39b287cc0ff7e405f4667c2bec8d6e2f2ce1ba2adb963bae4ca24b"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "39979b86e082c5b410fedc122268da0231096552"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "683892485c00460b9dbd5dbc59846999"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/el/6",
+          "name" : "opscode-push-jobs-client-1.1.5-1.el6.i686.rpm",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "502e7dcfc6b7178bbbbdc32b8813958d"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "fb5c2ebca4e5e7090795fb61659873ce0fe4f80066797e4f5892389d0ac8836d2aed8cc96f88a30929a015ca8d167e86f7172b4316f7761b8b99074c6081c0df"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "6526ebdfc92abd3103db3a57467000a56fdf0ca9"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "7ef751d41d6bc41f6c4e7b223b97704272ae403da6aa0560cfb268e0421248e4"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/el/6",
+          "name" : "opscode-push-jobs-client-1.1.5-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "60109bf7d527dc59029813b8bdb7d06717b6966a"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d242de41b983428057dfaa0d6b42a8710d1e6992b0235ee22cbf75f44873d77f"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "f078b34fbacb9fbc30cf6d810832f47de5d3f802806f6a357fe564a426cc62a74715a78ce1d61cb06f25086660bd5b56b96ed62ce14bd6eb38382d95bc50c0aa"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "5ea93f2ed28bc32357f3b73bba4b9728"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 9,
+          "total" : 9
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:37 GMT
+- request:
+    method: post
+    uri: http://mixlib-install:%25mKPtzbT1JH1wm333kjkkjs39oeuFLgZ8vNoOdLBPd%29TZAJsURs9w0HloWR%24l6h@artifactory.chef.co/api/search/aql
+    body:
+      encoding: UTF-8
+      string: |
+        items.find(
+          {"repo": "omnibus-stable-local"},
+          {"@omnibus.project": "opscode-push-jobs-client"},
+          {"@omnibus.version": "1.1.5"},
+          {"name": {"$nmatch": "*.metadata.json" }}
+        ).include("repo", "path", "name", "property")
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Artifactory Ruby Gem 2.3.3
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - text/plain
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.4.6 (Ubuntu)
+      Date:
+      - Thu, 07 Jul 2016 20:11:42 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Artifactory-Id:
+      - 74eddb6840a6545e:747da0c7:1552b7fe973:-7fd8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/ubuntu/10.04",
+          "name" : "opscode-push-jobs-client_1.1.5-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.04"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "0a8f5069b7281f5acb800290d2e18b766864d46597fc84548f14a17a5b437426"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "86bd4997cd666f73ad80c3927c750a8f4577e9e573cc5db645d9e1cba73cb35d2f57342711b3a829472eff5307c23b6a258bcec485c504c482f69174a5d94791"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "d319f63207ac51f78a58151e1c493ceb"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "7801746fabcf838c0396496b4826edbc8ec5a6e5"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/ubuntu/10.04",
+          "name" : "opscode-push-jobs-client_1.1.5-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "3f1de1454eaef5a9877c94f33982b381"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.04"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "1b1435aad98042d8b224181f45c2f5911aed8517f7a5b1429176c59bba807586"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "833c6201c3258e3fda27bf536a2f683c1d192ee0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "f87b4626997cb47c2ba73748d0d34eaff58f6138022a066b5dd24c7cd58f49cc44b633aa0a7269aa1ae59d4d67ebdccdef26f53684ba0f2cff93b695f167f26b"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/ubuntu/12.04",
+          "name" : "opscode-push-jobs-client_1.1.5-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "cf74fd95955739cc9ff70eebcbe59809"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d7b40ebb18c7c7dbc32322c9bcd721279e707fd1bee3609a37055838afbf67ea"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "c38e3a3f78e9b374268ef2179c19eb5116b69928014b905ea973890fabc078ddfada30c2a75df8a98a9abf72c6466b9ebc74abbb04285116c6f07868833dda53"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "d659c06c72397ed2bc6cd88488349857f1958538"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/ubuntu/12.04",
+          "name" : "opscode-push-jobs-client_1.1.5-1_i386.deb",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ae8904b0a58e05e6eb15f451211a9afff086fb008459d3abb5d6b6ac3a88617c56f0769d10179e662d2b25b17eb4f2c333a06121cbc36ef260b53be520410f63"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "07aed8fc0422b05be7f8362efde4716a70c0b312"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "a5df71751991e9a03def52247d0ac050"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "f2ab544c23507e1bfd5374da14161014cb45fae4d3f1acfe0de5712b5d7472db"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/windows/2008r2",
+          "name" : "opscode-push-jobs-client-windows-1.1.5-1.windows.msi",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "411520e6a2e3038cd018ffacee0e76e37e7badd1aa84de03f5469c19e8d6c576"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "daf4f5c35b9b86bd5aab5200bc0f22c0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2008r2"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "38b43b5895e44c4c64c5ae19337f7bc918ffdd2b"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "f079b97aae0589ffda6c60a2f6d71a9a4cdc988380e5f0947bb390f87122923b57db4bb75c6422a7c3f772fce70487c013b408942890ac7648f4b9f39b12a0f2"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/el/5",
+          "name" : "opscode-push-jobs-client-1.1.5-1.el5.i686.rpm",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "33e9dbcca06b3806ce99774644e78003"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "2a6f46880229234776d94f926af241547817c5190cc7340f4b5fa3383a236af7"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "8652cb8afc3670c96e94892bbd232dd6d8e302fe"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "018b49bf38fd43386c9d59bbf33ef1eff07d32133bf8d432af05a47031da456a1c0418a02d31581318a3fc1e86d8aac617b55f397660309add6bd66d25e76116"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/el/5",
+          "name" : "opscode-push-jobs-client-1.1.5-1.el5.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.sha256",
+            "value" : "98b80e02a989d2a7dd7eda29a5954f319648c8a11576aec33012661d7c9455c3"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "5"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "e1f000edb1931b3d3af33c2ae04fb42a09d45d9ae0ada1f986dc8b8bf7d644067359b68d5f39b287cc0ff7e405f4667c2bec8d6e2f2ce1ba2adb963bae4ca24b"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "39979b86e082c5b410fedc122268da0231096552"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "683892485c00460b9dbd5dbc59846999"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/el/6",
+          "name" : "opscode-push-jobs-client-1.1.5-1.el6.i686.rpm",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "502e7dcfc6b7178bbbbdc32b8813958d"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i686"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "fb5c2ebca4e5e7090795fb61659873ce0fe4f80066797e4f5892389d0ac8836d2aed8cc96f88a30929a015ca8d167e86f7172b4316f7761b8b99074c6081c0df"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "6526ebdfc92abd3103db3a57467000a56fdf0ca9"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "7ef751d41d6bc41f6c4e7b223b97704272ae403da6aa0560cfb268e0421248e4"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/opscode-push-jobs-client/1.1.5/el/6",
+          "name" : "opscode-push-jobs-client-1.1.5-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "60109bf7d527dc59029813b8bdb7d06717b6966a"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "d242de41b983428057dfaa0d6b42a8710d1e6992b0235ee22cbf75f44873d77f"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "f078b34fbacb9fbc30cf6d810832f47de5d3f802806f6a357fe564a426cc62a74715a78ce1d61cb06f25086660bd5b56b96ed62ce14bd6eb38382d95bc50c0aa"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "opscode-push-jobs-client"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "5ea93f2ed28bc32357f3b73bba4b9728"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.1.5"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 9,
+          "total" : 9
+        }
+        }
+    http_version: 
+  recorded_at: Thu, 07 Jul 2016 20:10:37 GMT
+recorded_with: VCR 3.0.3

--- a/spec/mixlib/install/backend/artifactory_all_channels_spec.rb
+++ b/spec/mixlib/install/backend/artifactory_all_channels_spec.rb
@@ -179,4 +179,58 @@ context "Mixlib::Install::Backend::Artifactory all channels", :vcr do
       expect(artifactory.info.url).to match "chef-compliance"
     end
   end
+
+  context "for push jobs client" do
+    let(:channel) { :stable }
+    let(:product_name) { "push-jobs-client" }
+    let(:platform) { "ubuntu" }
+    let(:platform_version) { "12.04" }
+    let(:architecture) { "x86_64" }
+
+    context "for version 1.1.5" do
+      let(:product_version) { "1.1.5" }
+
+      it "uses omnibus project name" do
+        expect(artifactory.info).to be_a Mixlib::Install::ArtifactInfo
+        expect(artifactory.info.url).to match "opscode-push-jobs-client"
+      end
+    end
+
+    context "for latest version" do
+      let(:product_version) { :latest }
+
+      it "uses omnibus project name" do
+        expect(artifactory.info).to be_a Mixlib::Install::ArtifactInfo
+        expect(artifactory.info.url).to match "push-jobs-client"
+        expect(artifactory.info.url).not_to match "opscode-push-jobs-client"
+      end
+    end
+  end
+
+  context "for manage" do
+    let(:channel) { :stable }
+    let(:product_name) { "manage" }
+    let(:platform) { "ubuntu" }
+    let(:platform_version) { "14.04" }
+    let(:architecture) { "x86_64" }
+
+    context "for version 1.21.0" do
+      let(:product_version) { "1.21.0" }
+
+      it "uses omnibus project name" do
+        expect(artifactory.info).to be_a Mixlib::Install::ArtifactInfo
+        expect(artifactory.info.url).to match "opscode-manage"
+      end
+    end
+
+    context "for latest version" do
+      let(:product_version) { :latest }
+
+      it "uses omnibus project name" do
+        expect(artifactory.info).to be_a Mixlib::Install::ArtifactInfo
+        expect(artifactory.info.url).to match "chef-manage"
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
When `omnibus_project` was set for a product where `package_name` was being passed a block to determine the name based on version, `omnibus_project` was being set to the Proc instance because it was defaulting to the `@package_name` instance variable. This should have been calling the `package_name` method.

The resulting error was:
```
 had an error: URI::InvalidURIError: bad URI(is not URI?): /api/build/#<Proc:0x00000008bff948@/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/mixlib-install-1.1.0/lib/mixlib/install/product.rb:233>
```

@rhass @sersut 