### PR TITLE
add known_omnibus_projects methods to Product

### DIFF
--- a/lib/mixlib/install/backend/artifactory.rb
+++ b/lib/mixlib/install/backend/artifactory.rb
@@ -132,6 +132,17 @@ items.find(
           results["results"]
         end
 
+        #
+        # Artifactory GET request
+        #
+        def get(url)
+          results = artifactory_request do
+            client.get(url)
+          end
+
+          results["results"]
+        end
+
         def create_artifact(artifact_map)
           platform, platform_version = normalize_platform(artifact_map["omnibus.platform"],
             artifact_map["omnibus.platform_version"])

--- a/lib/mixlib/install/backend/artifactory.rb
+++ b/lib/mixlib/install/backend/artifactory.rb
@@ -150,6 +150,7 @@ items.find(
           ArtifactInfo.new(
             md5:              artifact_map["omnibus.md5"],
             sha256:           artifact_map["omnibus.sha256"],
+            sha1:             artifact_map["omnibus.sha1"],
             version:          artifact_map["omnibus.version"],
             platform:         platform,
             platform_version: platform_version,

--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -72,10 +72,25 @@ module Mixlib
       #
       def omnibus_project(value = nil)
         if value.nil?
-          @omnibus_project || @package_name
+          @omnibus_project || package_name
         else
           @omnibus_project = value
         end
+      end
+
+      #
+      # Return all known omnibus project names for a product
+      #
+      def known_omnibus_projects
+        # iterate through min/max versions for all product names
+        # and collect the name for both versions
+        projects = %w{ 0.0.0 1000.1000.1000 }.collect do |v|
+          @version = v
+          omnibus_project
+        end
+        # remove duplicates and return multiple known names or return the single
+        # project name
+        projects.uniq || projects
       end
 
       #

--- a/spec/mixlib/install/product_spec.rb
+++ b/spec/mixlib/install/product_spec.rb
@@ -141,6 +141,10 @@ context "PRODUCT_MATRIX" do
   context "for chef-server" do
     let(:product_name) { "chef-server" }
 
+    it "should return only one known omnibus project name" do
+      expect(PRODUCT_MATRIX.lookup("chef-server").known_omnibus_projects).to eq ["chef-server"]
+    end
+
     context "for version > 12.0.0" do
       let(:version) { "12.0.5" }
 
@@ -168,6 +172,10 @@ context "PRODUCT_MATRIX" do
 
   context "for manage" do
     let(:product_name) { "manage" }
+
+    it "should return both known omnibus project name" do
+      expect(PRODUCT_MATRIX.lookup("manage").known_omnibus_projects).to eq ["opscode-manage", "chef-manage"]
+    end
 
     context "for version > 2.0.0" do
       let(:version) { "2.0.5" }
@@ -221,6 +229,10 @@ context "PRODUCT_MATRIX" do
   context "for push-jobs-server" do
     let(:product_name) { "push-jobs-server" }
 
+    it "should return only one known omnibus project name" do
+      expect(PRODUCT_MATRIX.lookup("push-jobs-server").known_omnibus_projects).to eq ["opscode-push-jobs-server"]
+    end
+
     context "for latest" do
       let(:version) { :latest }
 
@@ -248,6 +260,10 @@ context "PRODUCT_MATRIX" do
 
   context "for push-jobs-client" do
     let(:product_name) { "push-jobs-client" }
+
+    it "should return both known omnibus project name" do
+      expect(PRODUCT_MATRIX.lookup("push-jobs-client").known_omnibus_projects).to eq ["opscode-push-jobs-client", "push-jobs-client"]
+    end
 
     context "for version > 1.3.0" do
       let(:version) { "1.3.5" }


### PR DESCRIPTION
We need to provide an API for other tools (like Omnitruck) to collect a list of all project names given a product name without giving a version qualifier. For example, "manage" maps to projects "chef-manage" and "opscode-manage".

example:
```ruby
PRODUCT_MATRIX.lookup("manage").known_omnibus_projects
# => ["opscode-manage", "chef-manage"]
```

@rhass @schisamo 