### PR TITLE
Non-root provision without sudo privelege

### DIFF
--- a/support/install_command.sh
+++ b/support/install_command.sh
@@ -1,4 +1,10 @@
-tmp_stderr="/tmp/stderr";
+basedir="$HOME/.chef"
+
+if [ ! -d $basedir ]; then
+  mkdir -p $basedir
+fi
+
+tmp_stderr="$basedir/stderr";
 
 # capture_tmp_stderr SOURCE
 capture_tmp_stderr() {
@@ -215,8 +221,8 @@ main() {
       chef_omnibus_url=`echo "$chef_omnibus_url" | sed -e "s/https/http/"`;
     fi
 
-    do_download "$chef_omnibus_url" /tmp/install.sh;
-    $sudo_sh /tmp/install.sh $install_flags;
+    do_download "$chef_omnibus_url" $basedir/install.sh;
+    $sudo_sh $basedir/install.sh $install_flags;
   else
     echo "-----> Chef Omnibus installation detected (${pretty_version})";
   fi


### PR DESCRIPTION
In some environments chef-client can be executed from non-root user, who doesn't have sudo privilege as well. We have root and non-root provision for application user. So when root downloaded chef-client into /tmp, non-root fails to download it to the same location due to permission issue.
