### PR TITLE
Add support for Nano

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1
@@ -1,16 +1,22 @@
 function Get-PlatformVersion {
-  switch -regex ((get-wmiobject win32_operatingsystem).version) {
-    '10\.0\.\d+' {$platform_version = '2012r2'}
+  switch -regex ((Get-WMIQuery win32_operatingsystem).version) {
+    '10\.0\.\d+' {$platform_version = '2016'}
     '6\.3\.\d+'  {$platform_version = '2012r2'}
     '6\.2\.\d+'  {$platform_version = '2012'}
     '6\.1\.\d+'  {$platform_version = '2008r2'}
     '6\.0\.\d+'  {$platform_version = '2008'}
   }
+
+  if(Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Server\ServerLevels') {
+    $levels = Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Server\ServerLevels'
+    if($levels.NanoServer -eq 1) { $platform_version += 'nano' }
+  }
+
   return $platform_version
 }
 
 function Get-PlatformArchitecture {
-  if ((get-wmiobject win32_operatingsystem).osarchitecture -like '64-bit') {
+  if ((Get-WMIQuery win32_operatingsystem).osarchitecture -like '64-bit') {
     $architecture = 'x86_64'
   } else {
     $architecture = 'i386'
@@ -22,7 +28,8 @@ function New-Uri {
   param ($baseuri, $newuri)
 
   try {
-  new-object System.Uri $baseuri, $newuri
+    $base = new-object System.Uri $baseuri
+    new-object System.Uri $base, $newuri
   }
   catch [System.Management.Automation.MethodInvocationException]{
     Write-Error "$($_.exception.message)"
@@ -32,17 +39,13 @@ function New-Uri {
 
 function Get-WebContent {
   param ($uri, $filepath)
-  $proxy = New-Object -TypeName System.Net.WebProxy
-  $wc = new-object System.Net.WebClient
-  $proxy.Address = $env:http_proxy
-  $wc.Proxy = $proxy
 
   try {
-    if ([string]::IsNullOrEmpty($filepath)) {
-      $wc.downloadstring($uri)
+    if($PSVersionTable.PSEdition -eq 'Core') {
+      Get-WebContentOnCore $uri $filepath
     }
     else {
-      $wc.downloadfile($uri, $filepath)
+      Get-WebContentOnFullNet $uri $filepath
     }
   }
   catch {
@@ -56,6 +59,50 @@ function Get-WebContent {
   }
 }
 
+function Get-WebContentOnFullNet {
+  param ($uri, $filepath)
+
+  $proxy = New-Object -TypeName System.Net.WebProxy
+  $wc = new-object System.Net.WebClient
+  $proxy.Address = $env:http_proxy
+  $wc.Proxy = $proxy
+
+  if ([string]::IsNullOrEmpty($filepath)) {
+    $wc.downloadstring($uri)
+  }
+  else {
+    $wc.downloadfile($uri, $filepath)
+  }
+}
+
+function Get-WebContentOnCore {
+  param ($uri, $filepath)
+
+  $handler = New-Object System.Net.Http.HttpClientHandler
+  $client = New-Object System.Net.Http.HttpClient($handler)
+  $client.Timeout = New-Object System.TimeSpan(0, 30, 0)
+  $cancelTokenSource = [System.Threading.CancellationTokenSource]::new()
+  $responseMsg = $client.GetAsync([System.Uri]::new($uri), $cancelTokenSource.Token)
+  $responseMsg.Wait()
+  if (!$responseMsg.IsCanceled) {
+    $response = $responseMsg.Result
+    if ($response.IsSuccessStatusCode) {
+      if ([string]::IsNullOrEmpty($filepath)) {
+        $response.Content.ReadAsStringAsync().Result
+      }
+      else {
+        $downloadedFileStream = [System.IO.FileStream]::new($filepath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
+        $copyStreamOp = $response.Content.CopyToAsync($downloadedFileStream)
+        $copyStreamOp.Wait()
+        $downloadedFileStream.Close()
+        if ($copyStreamOp.Exception -ne $null) {
+          throw $copyStreamOp.Exception
+        }
+      }
+    }
+  }
+}
+
 function Test-ProjectPackage {
   [cmdletbinding()]
   param ($Path, $Algorithm = 'SHA256', $Hash)
@@ -66,7 +113,7 @@ function Test-ProjectPackage {
     function Get-FileHash ($Path, $Algorithm) {
       $Path = (resolve-path $path).providerpath
       $hash = @{Algorithm = $Algorithm; Path = $Path}
-      use ($c = New-Object -TypeName Security.Cryptography.SHA256Managed) {
+      use ($c = Get-SHA256Converter) {
         use ($in = (gi $path).OpenRead()) {
           $hash.Hash = ([BitConverter]::ToString($c.ComputeHash($in))).Replace("-", "").ToUpper()
         }
@@ -83,4 +130,24 @@ function Test-ProjectPackage {
     Write-Error "Failed to validate the downloaded installer.  The expected $Algorithm hash was '$Hash' and the actual hash was '$ActualHash' for $path"
   }
   return $Valid
+}
+
+function Get-SHA256Converter {
+  if($PSVersionTable.PSEdition -eq 'Core') {
+    [System.Security.Cryptography.SHA256]::Create()
+  }
+  else {
+    New-Object -TypeName Security.Cryptography.SHA256Managed
+  }
+}
+
+function Get-WMIQuery {
+  param ($class)
+
+  if(Get-Command -Name Get-CimInstance -ErrorAction SilentlyContinue) {
+    Get-CimInstance $class
+  }
+  else {
+    Get-WmiObject $class
+  }
 }

--- a/lib/mixlib/install/script_generator.rb
+++ b/lib/mixlib/install/script_generator.rb
@@ -132,7 +132,6 @@ module Mixlib
       def install_command_vars_for_powershell
         [
           shell_var("chef_omnibus_root", root),
-          shell_var("msi", "$env:TEMP\\chef-#{version}.msi"),
         ].tap do |vars|
           if install_msi_url
             vars << shell_var("chef_msi_url", install_msi_url)


### PR DESCRIPTION
This PR adds support for installing chef on Windows Nano. It two key code adjustments:

1. Detect if running on the `.net core` runtime and use the appropriate APIs. Most of this is just namespace changes but downloading internet content is a pretty big change.
2. If installing a file with a `.appx` extension, use the appx packaging mechanisms for detection, install and upgrade of the client.

A few things to note:
* Non-nano versions of windows should behave without any change to current logic
* There is no proxy support for nano yet. That should be addressed but I had issues getting `IWebProxy` properly implemented and am putting this to the side for now.
* The appx packager installs all packages to a common "application store" on disk. This is problematic because the path contains spaces and is also non deterministic. Therefore we create a symbolic link pointing the `omnibus_install_root` path to the actual appx `InstallLocation`

Testing:
I have tested nano installs and updates and also tested on 2012R2 to ensure current functionality still works as expected. I have tested under the following conditions:
* using a provided `install_msi_url` to force an appx
* using specific versions and also `latest`
* specifying product name and version and channel

Today nano users will have to specify a `install_msi_url` for nano since omnitruck is not serving appx packages. The following urls are publicly accessible:

```
https://s3-us-west-2.amazonaws.com/nano-chef-client/chef-12.14.57.appx
https://s3-us-west-2.amazonaws.com/nano-chef-client/chef-12.14.60.appx
```

One can test this with a Windows Nano Technical Preview 5 vagrant box. I have a packer template that builds these and it is accessible on Atlas via `mwrock/WindowsNano`.

I have tested faking metadata info to ensure that once omnitruck does begin serving appx packages, the code in this PR should work, but in the meantime use a .kitchen.yml like:

```
---
driver:
  name: vagrant

provisioner:
  name: chef_zero
  install_msi_url: https://s3-us-west-2.amazonaws.com/nano-chef-client/chef-12.14.60.appx

platforms:
- name: windows-nano
  driver_config:
    box: mwrock/WindowsNano
```

If testing with Test-Kitchen, use the `nano` branch which includes a very small .net core compatibility adjustment.