### PR TITLE
Release 1.2.2 with forced lf line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Managing line ending conversions
+# See http://git-scm.com/docs/gitattributes#_end-of-line_conversion
+* text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.2.2]
+- Add a .gitattributes file to ensure files are checked out with lf line endings
+
 ## [1.2.1]
 - Fix nano appx installs replacing the symlink with a full copy
 

--- a/lib/mixlib/install/version.rb
+++ b/lib/mixlib/install/version.rb
@@ -1,5 +1,5 @@
 module Mixlib
   class Install
-    VERSION = "1.2.1"
+    VERSION = "1.2.2"
   end
 end


### PR DESCRIPTION
Just for sanity sake I recloned with this branch, built a gem on windows, scp'd it to my linux box, installed it and confirmed no line endings in the files.