### PR TITLE
Add InSpec to the product matrix for availability via chef-ingredient

### DIFF
--- a/PRODUCT_MATRIX.md
+++ b/PRODUCT_MATRIX.md
@@ -12,6 +12,7 @@
 | Chef Compliance | compliance |
 | Delivery | delivery |
 | Chef Server High Availability addon | ha |
+| InSpec | inspec |
 | Management Console | manage |
 | Chef Cloud Marketplace addon | marketplace |
 | Omnibus Toolchain | omnibus-toolchain |

--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -250,6 +250,11 @@ PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
     config_file "/etc/opscode/chef-server.rb"
   end
 
+  product "inspec" do
+    product_name "InSpec"
+    package_name "inspec"
+  end
+
   product "manage" do
     product_name "Management Console"
     package_name do |v|

--- a/spec/mixlib/install/product_spec.rb
+++ b/spec/mixlib/install/product_spec.rb
@@ -118,6 +118,7 @@ context "PRODUCT_MATRIX" do
     compliance
     delivery
     ha
+    inspec
     manage
     marketplace
     omnibus-toolchain
@@ -130,6 +131,10 @@ context "PRODUCT_MATRIX" do
   }
 
   it "has entries for all #{CHEF_PRODUCTS.length} products" do
+    expect(PRODUCT_MATRIX.products).to eq CHEF_PRODUCTS
+  end
+
+  it "can lookup entries for all #{CHEF_PRODUCTS.length} products" do
     CHEF_PRODUCTS.each do |p|
       expect(PRODUCT_MATRIX.lookup(p).product_name).to be_a(String)
     end


### PR DESCRIPTION
and omnitruck.

cc @arlimus @chris-rock @chef/engineering-services 