### PR TITLE
Removing extraneous line breaks from Windows install logging.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ addons:
       - unzip
       - ssh
 
-branches:
-  only:
-  - master
-
 install:
   - echo "skip bundle install"
 
@@ -25,15 +21,7 @@ before_script:
   - export PATH="$PWD/bin:$PATH"
 
 script:
-  # run unit tests
-  - /opt/chefdk/embedded/bin/bundle install && /opt/chefdk/bin/chef exec rake
-  # setup acceptance tests
-  - cd acceptance && export BUNDLE_GEMFILE=$PWD/Gemfile && /opt/chefdk/embedded/bin/bundle install && export APPBUNDLER_ALLOW_RVM=true
-  # run acceptances tests and force cleanup
-  # only testing bourne until issues with powershell suite resovled:
-  # 1) inspec not finding chef package once connected (not reproducible locally)
-  # 2) currently no way to mask password (sensitive true) AND know what the error is if inspec fails
-  - /opt/chefdk/embedded/bin/bundle exec chef-acceptance test bourne --force-destroy
+  - ci/script.sh
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ addons:
       - unzip
       - ssh
 
+branches:
+  only:
+  - master
+
 install:
   - echo "skip bundle install"
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -evx
+
+# run unit tests
+/opt/chefdk/embedded/bin/bundle install && /opt/chefdk/bin/chef exec rake
+
+# Don't run acceptance tests on forks. The decryption keys are not available.
+if [ "${TRAVIS_REPO_SLUG}" = "chef/mixlib-install" ]; then
+  # setup acceptance tests
+  cd acceptance && export BUNDLE_GEMFILE=$PWD/Gemfile && /opt/chefdk/embedded/bin/bundle install && export APPBUNDLER_ALLOW_RVM=true
+  # run acceptances tests and force cleanup
+  # only testing bourne until issues with powershell suite resovled:
+  # 1) inspec not finding chef package once connected (not reproducible locally)
+  # 2) currently no way to mask password (sensitive true) AND know what the error is if inspec fails
+  /opt/chefdk/embedded/bin/bundle exec chef-acceptance test bourne --force-destroy
+fi

--- a/support/install_command.ps1
+++ b/support/install_command.ps1
@@ -102,7 +102,7 @@ Function Install-ChefAppx($appx, $chef_omnibus_root) {
   return $true
 }
 
-Function Log($m) { Write-Host "       $m`n" }
+Function Log($m) { Write-Host "       $m" }
 
 function Get-WebContent {
   param ($uri, $filepath)
@@ -178,7 +178,7 @@ Function Unresolve-Path($p) {
 $chef_omnibus_root = Unresolve-Path $chef_omnibus_root
 
 if (Check-UpdateChef $chef_omnibus_root $version) {
-  Write-Host "-----> Installing Chef Omnibus ($pretty_version)`n"
+  Write-Host "-----> Installing Chef Omnibus ($pretty_version)"
   if ($chef_metadata_url -ne $null) {
     $url, $sha256 = Get-ChefMetadata "$chef_metadata_url"
   } else {
@@ -190,5 +190,5 @@ if (Check-UpdateChef $chef_omnibus_root $version) {
   Download-Chef "$url" $sha256 $msi
   Install-Chef $msi $chef_omnibus_root
 } else {
-  Write-Host "-----> Chef Omnibus installation detected ($pretty_version)`n"
+  Write-Host "-----> Chef Omnibus installation detected ($pretty_version)"
 }


### PR DESCRIPTION
This change simply removes the additional line breaks that appear during installation on the Windows platform, reducing the gaps in the logged output.

Before:
![before](https://cloud.githubusercontent.com/assets/6384654/18794093/d4e8ec18-81b5-11e6-8954-701f3f27bb06.PNG)

After:
![after](https://cloud.githubusercontent.com/assets/6384654/18794108/e79031e6-81b5-11e6-8886-966ebd7f54dc.PNG)




Signed-off-by: Stuart Preston <stuart@pendrica.com>