### PR TITLE
add condition to allow omnitruck to accept unstable channel requests

### DIFF
--- a/lib/mixlib/install/generator/bourne.rb
+++ b/lib/mixlib/install/generator/bourne.rb
@@ -45,8 +45,14 @@ module Mixlib
           install_command << get_script("helpers.sh")
           install_command << render_variables
           install_command << get_script("platform_detection.sh")
-          install_command << get_script("fetch_metadata.sh")
-          install_command << get_script("fetch_package.sh")
+          # TODO: Remove this condition check once the PackageRouter changes for
+          #   omnitruck are delivered to production! For now, we will allow
+          #   unstable channel requests to omnitruck to use the acceptance environment.
+          if options.channel == :unstable
+            install_command << get_script("fetch_metadata.sh", base_url: "https://omnitruck-acceptance.chef.io/")
+          else
+            install_command << get_script("fetch_metadata.sh")
+          end
           install_command << get_script("install_package.sh")
 
           install_command.join("\n\n")

--- a/lib/mixlib/install/generator/powershell.rb
+++ b/lib/mixlib/install/generator/powershell.rb
@@ -46,9 +46,15 @@ module Mixlib
         def install_command
           install_project_module = []
           install_project_module << get_script("helpers.ps1")
-          install_project_module << get_script("get_project_metadata.ps1")
+          # TODO: Remove this condition check once the PackageRouter changes for
+          #   omnitruck are delivered to production! For now, we will allow
+          #   unstable channel requests to omnitruck to use the acceptance environment.
+          if options.channel == :unstable
+            install_project_module << get_script("get_project_metadata.ps1", base_url: "https://omnitruck-acceptance.chef.io/")
+          else
+            install_project_module << get_script("get_project_metadata.ps1")
+          end
           install_project_module << get_script("install_project.ps1")
-
           install_command = []
           install_command << ps1_modularize(install_project_module.join("\n"), "Omnitruck")
           install_command << render_command

--- a/spec/mixlib/install/generator_spec.rb
+++ b/spec/mixlib/install/generator_spec.rb
@@ -111,4 +111,27 @@ context "Mixlib::Install::Generator", :vcr do
       end
     end
   end
+
+  # TODO: These tests will need to be removed once the package router changes for omnitruck land in prod
+  context "for unstable channel" do
+    let(:channel) { :unstable }
+
+    context "for bourne" do
+      it "uses the acceptance environment" do
+        expect(install_script).to include("metadata_url=\"https://omnitruck-acceptance.chef.io/")
+      end
+    end
+
+    context "for powershell" do
+      let(:add_options) do
+        {
+          shell_type: :ps1,
+        }
+      end
+
+      it "uses the acceptance environment" do
+        expect(install_script).to include("[uri]$base_server_uri = 'https://omnitruck-acceptance.chef.io/'")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This change will reverted once the omnitruck changes with package router have been deployed to production. This is a stop gap solution so unstable requests that depend on the install scripts (sh/ps1) will work. 

This was discovered during acceptance testing for test-kitchen while trying to install a package from unstable.

@chef/engineering-services @sersut @rhass @mwrock 