### PR TITLE
remove omnitruck-acceptance condition

### DIFF
--- a/lib/mixlib/install/generator/bourne.rb
+++ b/lib/mixlib/install/generator/bourne.rb
@@ -45,14 +45,7 @@ module Mixlib
           install_command << get_script("helpers.sh")
           install_command << render_variables
           install_command << get_script("platform_detection.sh")
-          # TODO: Remove this condition check once the PackageRouter changes for
-          #   omnitruck are delivered to production! For now, we will allow
-          #   unstable channel requests to omnitruck to use the acceptance environment.
-          if options.channel == :unstable
-            install_command << get_script("fetch_metadata.sh", base_url: "https://omnitruck-acceptance.chef.io/")
-          else
-            install_command << get_script("fetch_metadata.sh")
-          end
+          install_command << get_script("fetch_metadata.sh")
           install_command << get_script("fetch_package.sh")
           install_command << get_script("install_package.sh")
 

--- a/lib/mixlib/install/generator/powershell.rb
+++ b/lib/mixlib/install/generator/powershell.rb
@@ -46,14 +46,7 @@ module Mixlib
         def install_command
           install_project_module = []
           install_project_module << get_script("helpers.ps1")
-          # TODO: Remove this condition check once the PackageRouter changes for
-          #   omnitruck are delivered to production! For now, we will allow
-          #   unstable channel requests to omnitruck to use the acceptance environment.
-          if options.channel == :unstable
-            install_project_module << get_script("get_project_metadata.ps1", base_url: "https://omnitruck-acceptance.chef.io/")
-          else
-            install_project_module << get_script("get_project_metadata.ps1")
-          end
+          install_project_module << get_script("get_project_metadata.ps1")
           install_project_module << get_script("install_project.ps1")
           install_command = []
           install_command << ps1_modularize(install_project_module.join("\n"), "Omnitruck")

--- a/spec/mixlib/install/generator_spec.rb
+++ b/spec/mixlib/install/generator_spec.rb
@@ -111,27 +111,4 @@ context "Mixlib::Install::Generator", :vcr do
       end
     end
   end
-
-  # TODO: These tests will need to be removed once the package router changes for omnitruck land in prod
-  context "for unstable channel" do
-    let(:channel) { :unstable }
-
-    context "for bourne" do
-      it "uses the acceptance environment" do
-        expect(install_script).to include("metadata_url=\"https://omnitruck-acceptance.chef.io/")
-      end
-    end
-
-    context "for powershell" do
-      let(:add_options) do
-        {
-          shell_type: :ps1,
-        }
-      end
-
-      it "uses the acceptance environment" do
-        expect(install_script).to include("[uri]$base_server_uri = 'https://omnitruck-acceptance.chef.io/'")
-      end
-    end
-  end
 end


### PR DESCRIPTION
This removes the hack to temporarily allow unstable package requests for the install scripts to hit the omnitruck-acceptance endpoint.

We will release this just before delivering omnitruck.

@schisamo 