### PR TITLE
Normalize auto detect platform architectures

### DIFF
--- a/lib/mixlib/install/backend/base.rb
+++ b/lib/mixlib/install/backend/base.rb
@@ -175,6 +175,25 @@ module Mixlib
 
           [platform, platform_version]
         end
+
+        #
+        # Normalizes architecture information that we receive from omnibus.architecture
+        #
+        # @param [String] architecture
+        #
+        # @return String [architecture]
+        def normalize_architecture(architecture)
+          case architecture
+          when "amd64"
+            "x86_64"
+          when "x86", "i86pc", "i686"
+            "i386"
+          when "sun4u", "sun4v"
+            "sparc"
+          else
+            architecture
+          end
+        end
       end
     end
   end

--- a/lib/mixlib/install/backend/package_router.rb
+++ b/lib/mixlib/install/backend/package_router.rb
@@ -42,7 +42,6 @@ module Mixlib
                       else
                         artifacts_for_version(options.product_version)
                       end
-
           windows_artifact_fixup!(artifacts)
         end
 
@@ -225,20 +224,6 @@ Can not find any builds for #{options.product_name} in #{endpoint}.
 
         def omnibus_project
           @omnibus_project ||= PRODUCT_MATRIX.lookup(options.product_name, options.product_version).omnibus_project
-        end
-
-        #
-        # Normalizes architecture information that we receive.
-        #
-        # @param [String] architecture
-        #
-        # @return String [architecture]
-        def normalize_architecture(architecture)
-          if %w{ sun4u sun4v }.include?(architecture)
-            architecture = "sparc"
-          end
-
-          architecture
         end
       end
     end

--- a/spec/mixlib/install/backend/package_router_spec.rb
+++ b/spec/mixlib/install/backend/package_router_spec.rb
@@ -295,4 +295,32 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
       expect(package_router.info.url).to match "chef-server-core"
     end
   end
+
+  context "architecture normalization" do
+    let(:channel) { :stable }
+    let(:product_name) { "chef" }
+    let(:product_version) { :latest }
+
+    context "when amd64" do
+      it "returns x86_84" do
+        expect(package_router.normalize_architecture("amd64")).to eq "x86_64"
+      end
+    end
+
+    %w{x86 i86pc i686}.each do |a|
+      context "when #{a}" do
+        it "returns i386" do
+          expect(package_router.normalize_architecture(a)).to eq "i386"
+        end
+      end
+    end
+
+    %w{sun4u sun4v}.each do |a|
+      context "when #{a}" do
+        it "returns sparc" do
+          expect(package_router.normalize_architecture(a)).to eq "sparc"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
@chef/engineering-services 

-from wrightp
With these changes I can GET from local omnitruck server:
`0.0.0.0:8080/stable/chef/metadata?p=el&pv=6&m=i386`

and receive:
```
sha1	f8c10dc7f1fefd4dea60473fb269a889c07d0b0a
sha256	c571b2a1a89ea205c824f23fec14f36b5c209908cd98f1b4a3417e5e68461b2e
url	https://packages.chef.io/files/stable/chef/12.14.89/el/6/chef-12.14.89-1.el6.i386.rpm
version	12.14.89
```

need confirmation that this is the desired result.