### PR TITLE
fix cumulus platform detection

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -29,9 +29,9 @@ if test -f "/etc/lsb-release" && grep -q DISTRIB_ID /etc/lsb-release && ! grep -
   platform=`grep DISTRIB_ID /etc/lsb-release | cut -d "=" -f 2 | tr '[A-Z]' '[a-z]'`
   platform_version=`grep DISTRIB_RELEASE /etc/lsb-release | cut -d "=" -f 2`
 
-  if test "$platform" = "cumulus linux"; then
+  if test "$platform" = "\"cumulus linux\""; then
     platform="cumulus_linux"
-  elif test "$platform" = "cumulus networks"; then
+  elif test "$platform" = "\"cumulus networks\""; then
     platform="cumulus_networks"
   fi
 


### PR DESCRIPTION
`/etc/lsb-release` looks like this
```
DISTRIB_ID="Cumulus Linux"
```

The double quotes are included as part of the string and need to be escaped. 🍼 

@isharacomix

Signed-off-by: Patrick Wright <patrick@chef.io>