### PR TITLE
add user agent request header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,22 @@ Mixlib::Install.available_versions("chef", "stable")
 # => ["12.13.3", "12.13.7"]
 ```
 
+### User-Agent Request Headers
+By default, all requests made by `mixlib-install` will include a `User-Agent` request header as `mixlib-install/<version>`.
+Additional `User-Agent` request headers can be added by setting the `user_agent_headers` option.
+When you want to identify a product using mixlib-install as a dependency we recommend the format `product/version`.
+```ruby
+options = {
+  channel: :stable,
+  product_name: 'chef',
+  user_agent_headers: ["my_product/1.2.3", "somethingelse"],
+}
+```
+
 ### Collecting Software Dependencies and License Content
 Collecting software dependencies and license content for ArtifactInfo instances
 requires additional requests to the repository server. By default, collection is disabled.
 To return data for instance methods `software_dependencies` and `license_content`, the `include_metadata` option must be enabled.
-
 ```
 options = {
   channel: :current,

--- a/lib/mixlib/install/backend/package_router.rb
+++ b/lib/mixlib/install/backend/package_router.rb
@@ -147,14 +147,30 @@ Can not find any builds for #{options.product_name} in #{endpoint}.
           uri = URI.parse(endpoint)
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = (uri.scheme == "https")
-
           full_path = File.join(uri.path, url)
-          request = Net::HTTP::Get.new(full_path)
 
-          res = http.request(request)
+          res = http.request(create_http_request(full_path))
 
           res.value
           JSON.parse(res.body)
+        end
+
+        def create_http_request(full_path)
+          require "mixlib/install/version"
+
+          request = Net::HTTP::Get.new(full_path)
+
+          user_agents = ["mixlib-install/#{Mixlib::Install::VERSION}"]
+
+          if options.user_agent_headers
+            options.user_agent_headers.each do |header|
+              user_agents << header
+            end
+          end
+
+          request.add_field("User-Agent", user_agents.join(" "))
+
+          request
         end
 
         def create_artifact(artifact_map)

--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -39,6 +39,7 @@ module Mixlib
         :shell_type,
         :platform_version_compatibility_mode,
         :include_metadata,
+        :user_agent_headers,
       ]
 
       def initialize(options)
@@ -57,6 +58,7 @@ module Mixlib
         errors << validate_product_names
         errors << validate_channels
         errors << validate_shell_type
+        errors << validate_user_agent_headers
 
         unless errors.compact.empty?
           raise InvalidOptions, errors.join("\n")
@@ -132,6 +134,20 @@ Must be one of: #{SUPPORTED_SHELL_TYPES.join(", ")}
         end
       end
 
+      def validate_user_agent_headers
+        error = nil
+        if user_agent_headers
+          if user_agent_headers.is_a? Array
+            user_agent_headers.each do |header|
+              error = "user agent headers can not have spaces." if header.include?(" ")
+            end
+          else
+            error = "user_agent_headers must be an Array."
+          end
+        end
+
+        error
+      end
     end
   end
 end

--- a/spec/mixlib/install/backend/package_router_spec.rb
+++ b/spec/mixlib/install/backend/package_router_spec.rb
@@ -19,6 +19,7 @@
 require "spec_helper"
 require "mixlib/install/options"
 require "mixlib/install/backend/package_router"
+require "mixlib/install/version"
 
 context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
   let(:channel) { nil }
@@ -27,6 +28,7 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
   let(:platform) { nil }
   let(:platform_version) { nil }
   let(:architecture) { nil }
+  let(:user_agent_headers) { nil }
   let(:pv_compat) { nil }
   let(:include_metadata) { nil }
 
@@ -37,6 +39,7 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
       opt[:channel] = channel
       opt[:platform_version_compatibility_mode] = pv_compat if pv_compat
       opt[:include_metadata] = include_metadata if include_metadata
+      opt[:user_agent_headers] = user_agent_headers if user_agent_headers
       if platform
         opt[:platform] = platform
         opt[:platform_version] = platform_version
@@ -376,6 +379,23 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
         it "returns sparc" do
           expect(package_router.normalize_architecture(a)).to eq "sparc"
         end
+      end
+    end
+  end
+
+  context "user agents" do
+    let(:channel) { :stable }
+    let(:product_name) { "chef" }
+
+    it "always includes default header" do
+      expect(package_router.create_http_request("/").get_fields("user-agent")).to include "mixlib-install/#{Mixlib::Install::VERSION}"
+    end
+
+    context "with custom agents" do
+      let(:user_agent_headers) { ["foo/bar", "someheader"] }
+
+      it "sets custom header" do
+        expect(package_router.create_http_request("/").get_fields("user-agent")).to include /foo\/bar someheader/
       end
     end
   end

--- a/spec/mixlib/install/options_spec.rb
+++ b/spec/mixlib/install/options_spec.rb
@@ -27,6 +27,7 @@ context "Mixlib::Install::Options" do
   let(:platform_version) { nil }
   let(:architecture) { nil }
   let(:shell_type) { nil }
+  let(:user_agent_headers) { nil }
 
   context "for invalid product name option" do
     let(:product_name) { "foo" }
@@ -45,14 +46,29 @@ context "Mixlib::Install::Options" do
   end
 
   context "for platform options" do
-    let(:product_name) { "chef" }
-    let(:product_version) { "1.2.3" }
-
     context "for shell type options" do
       let(:shell_type) { :foo }
 
       it "raises invalid shell type error" do
         expect { Mixlib::Install.new(shell_type: shell_type) }.to raise_error(Mixlib::Install::Options::InvalidOptions, /Unknown shell type/)
+      end
+    end
+  end
+
+  context "for user_agents option" do
+    context "passed as a string" do
+      let(:user_agent_headers) { "myString" }
+
+      it "raises an error" do
+        expect { Mixlib::Install.new(product_name: "chef", channel: :stable, user_agent_headers: user_agent_headers) }.to raise_error(Mixlib::Install::Options::InvalidOptions, /user_agent_headers must be an Array/)
+      end
+    end
+
+    context "headers passed with spaces" do
+      let(:user_agent_headers) { ["a", "b c"] }
+
+      it "raises an error" do
+        expect { Mixlib::Install.new(product_name: "chef", channel: :stable, user_agent_headers: user_agent_headers) }.to raise_error(Mixlib::Install::Options::InvalidOptions, /user agent headers can not have spaces/)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,7 +51,7 @@ VCR.configure do |config|
   # config.default_cassette_options = { :record => :all }
   #
   # Records new http calls without changing existing fixtures
-  # config.default_cassette_options = { :record => :new_episodes }
+  config.default_cassette_options = { :record => :new_episodes }
 end
 
 # Copied directly from


### PR DESCRIPTION
- all requests will include a default mixlib-install header
- new option to set addition user agent headers
- vcr record new episodes option defaulted to be enabled

Custom headers will look like `mixlib-install/1.1.1 someheader`

Signed-off-by: Patrick Wright <patrick@chef.io>

@chef/engineering-services 