### PR TITLE
Add `install_path` value to product details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [2.1.5]
+- Add `install_path` properties to the products inside PRODUCT_MATRIX.
+
 ## [2.1.4]
 - Fix Cumulus Linux and Cumulus Networks platform detection
 

--- a/lib/mixlib/install/version.rb
+++ b/lib/mixlib/install/version.rb
@@ -1,5 +1,5 @@
 module Mixlib
   class Install
-    VERSION = "2.1.4"
+    VERSION = "2.1.5"
   end
 end

--- a/spec/mixlib/install/product_spec.rb
+++ b/spec/mixlib/install/product_spec.rb
@@ -89,6 +89,8 @@ context "Mixlib::Install::Product" do
     expect(Mixlib::Install::Product::DSL_PROPERTIES).to include(:package_name)
     expect(Mixlib::Install::Product::DSL_PROPERTIES).to include(:ctl_command)
     expect(Mixlib::Install::Product::DSL_PROPERTIES).to include(:config_file)
+    expect(Mixlib::Install::Product::DSL_PROPERTIES).to include(:install_path)
+    expect(Mixlib::Install::Product::DSL_PROPERTIES).to include(:omnibus_project)
   end
 end
 
@@ -103,6 +105,10 @@ context "PRODUCT_MATRIX" do
 
   let(:config_file) do
     PRODUCT_MATRIX.lookup(product_name, version).config_file
+  end
+
+  let(:install_path) do
+    PRODUCT_MATRIX.lookup(product_name, version).install_path
   end
 
   CHEF_PRODUCTS = %w{
@@ -166,6 +172,10 @@ context "PRODUCT_MATRIX" do
       it "should return correct package_name" do
         expect(package_name).to eq("chef-server-core")
       end
+
+      it "should return correct install_path" do
+        expect(install_path).to eq("/opt/opscode")
+      end
     end
 
     context "for latest" do
@@ -174,6 +184,10 @@ context "PRODUCT_MATRIX" do
       it "should return correct package_name" do
         expect(package_name).to eq("chef-server-core")
       end
+
+      it "should return correct install_path" do
+        expect(install_path).to eq("/opt/opscode")
+      end
     end
 
     context "for < 12.0.0, > 11.0.0" do
@@ -181,6 +195,10 @@ context "PRODUCT_MATRIX" do
 
       it "should return correct package_name" do
         expect(package_name).to eq("chef-server")
+      end
+
+      it "should return correct install_path" do
+        expect(install_path).to eq("/opt/chef-server")
       end
     end
   end
@@ -206,6 +224,10 @@ context "PRODUCT_MATRIX" do
       it "should return correct config_file" do
         expect(config_file).to eq("/etc/chef-manage/manage.rb")
       end
+
+      it "should return correct install_path" do
+        expect(install_path).to eq("/opt/chef-manage")
+      end
     end
 
     context "for latest" do
@@ -222,6 +244,10 @@ context "PRODUCT_MATRIX" do
       it "should return correct config_file" do
         expect(config_file).to eq("/etc/chef-manage/manage.rb")
       end
+
+      it "should return correct install_path" do
+        expect(install_path).to eq("/opt/chef-manage")
+      end
     end
 
     context "for < 2.0.0" do
@@ -237,6 +263,10 @@ context "PRODUCT_MATRIX" do
 
       it "should return correct config_file" do
         expect(config_file).to eq("/etc/opscode-manage/manage.rb")
+      end
+
+      it "should return correct install_path" do
+        expect(install_path).to eq("/opt/opscode-manage")
       end
     end
   end


### PR DESCRIPTION
Get/Set the installation path for any given product. Defaults to
"/opt/[product_name]".