### PR TITLE
[JEX-362] add user agent headers to all download requests

### DIFF
--- a/lib/mixlib/install/backend/package_router.rb
+++ b/lib/mixlib/install/backend/package_router.rb
@@ -20,6 +20,7 @@ require "json"
 require "mixlib/install/artifact_info"
 require "mixlib/install/backend/base"
 require "mixlib/install/product"
+require "mixlib/install/util"
 require "net/http"
 
 module Mixlib
@@ -156,19 +157,9 @@ Can not find any builds for #{options.product_name} in #{endpoint}.
         end
 
         def create_http_request(full_path)
-          require "mixlib/install/version"
-
           request = Net::HTTP::Get.new(full_path)
 
-          user_agents = ["mixlib-install/#{Mixlib::Install::VERSION}"]
-
-          if options.user_agent_headers
-            options.user_agent_headers.each do |header|
-              user_agents << header
-            end
-          end
-
-          request.add_field("User-Agent", user_agents.join(" "))
+          request.add_field("User-Agent", Util.user_agent_string(options.user_agent_headers))
 
           request
         end

--- a/lib/mixlib/install/generator/base.rb
+++ b/lib/mixlib/install/generator/base.rb
@@ -17,6 +17,7 @@
 
 require "erb"
 require "ostruct"
+require "mixlib/install/util"
 
 module Mixlib
   class Install
@@ -47,6 +48,7 @@ module Mixlib
           if File.exist? "#{script_path}.erb"
             # Default values to use incase they are not set in the context
             context[:base_url] ||= "https://omnitruck.chef.io"
+            context[:user_agent_string] = Util.user_agent_string(context[:user_agent_headers])
 
             context_object = OpenStruct.new(context).instance_eval { binding }
             ERB.new(File.read("#{script_path}.erb")).result(context_object)

--- a/lib/mixlib/install/generator/bourne.rb
+++ b/lib/mixlib/install/generator/bourne.rb
@@ -23,7 +23,7 @@ module Mixlib
       class Bourne < Base
         def self.install_sh(context)
           install_command = []
-          install_command << get_script("helpers.sh")
+          install_command << get_script("helpers.sh", context)
           install_command << get_script("script_cli_parameters.sh")
           install_command << get_script("platform_detection.sh")
           install_command << get_script("fetch_metadata.sh", context)
@@ -42,7 +42,7 @@ module Mixlib
 
         def install_command
           install_command = []
-          install_command << get_script("helpers.sh")
+          install_command << get_script("helpers.sh", user_agent_headers: options.user_agent_headers)
           install_command << render_variables
           install_command << get_script("platform_detection.sh")
           install_command << get_script("fetch_metadata.sh")

--- a/lib/mixlib/install/generator/bourne/scripts/helpers.sh.erb
+++ b/lib/mixlib/install/generator/bourne/scripts/helpers.sh.erb
@@ -115,7 +115,7 @@ capture_tmp_stderr() {
 # do_wget URL FILENAME
 do_wget() {
   echo "trying wget..."
-  wget -O "$2" "$1" 2>$tmp_dir/stderr
+  wget --user-agent="User-Agent: <%= user_agent_string %>" -O "$2" "$1" 2>$tmp_dir/stderr
   rc=$?
   # check for 404
   grep "ERROR 404" $tmp_dir/stderr 2>&1 >/dev/null
@@ -136,7 +136,7 @@ do_wget() {
 # do_curl URL FILENAME
 do_curl() {
   echo "trying curl..."
-  curl --retry 5 -sL -D $tmp_dir/stderr "$1" > "$2"
+  curl -A "User-Agent: <%= user_agent_string %>" --retry 5 -sL -D $tmp_dir/stderr "$1" > "$2"
   rc=$?
   # check for 404
   grep "404 Not Found" $tmp_dir/stderr 2>&1 >/dev/null
@@ -157,7 +157,7 @@ do_curl() {
 # do_fetch URL FILENAME
 do_fetch() {
   echo "trying fetch..."
-  fetch -o "$2" "$1" 2>$tmp_dir/stderr
+  fetch --user-agent="User-Agent: <%= user_agent_string %>" -o "$2" "$1" 2>$tmp_dir/stderr
   # check for bad return status
   test $? -ne 0 && return 1
   return 0
@@ -187,7 +187,7 @@ do_perl() {
 # do_python URL FILENAME
 do_python() {
   echo "trying python..."
-  python -c "import sys,urllib2 ; sys.stdout.write(urllib2.urlopen(sys.argv[1]).read())" "$1" > "$2" 2>$tmp_dir/stderr
+  python -c "import sys,urllib2; sys.stdout.write(urllib2.urlopen(urllib2.Request(sys.argv[1], headers={ 'User-Agent': '<%= user_agent_string %>' })).read())" "$1" > "$2" 2>$tmp_dir/stderr
   rc=$?
   # check for 404
   grep "HTTP Error 404" $tmp_dir/stderr 2>&1 >/dev/null

--- a/lib/mixlib/install/generator/powershell.rb
+++ b/lib/mixlib/install/generator/powershell.rb
@@ -23,7 +23,7 @@ module Mixlib
       class PowerShell < Base
         def self.install_ps1(context)
           install_project_module = []
-          install_project_module << get_script("helpers.ps1")
+          install_project_module << get_script("helpers.ps1", context)
           install_project_module << get_script("get_project_metadata.ps1", context)
           install_project_module << get_script("install_project.ps1")
 
@@ -45,7 +45,7 @@ module Mixlib
 
         def install_command
           install_project_module = []
-          install_project_module << get_script("helpers.ps1")
+          install_project_module << get_script("helpers.ps1", user_agent_headers: options.user_agent_headers)
           install_project_module << get_script("get_project_metadata.ps1")
           install_project_module << get_script("install_project.ps1")
           install_command = []

--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
@@ -64,6 +64,7 @@ function Get-WebContentOnFullNet {
 
   $proxy = New-Object -TypeName System.Net.WebProxy
   $wc = new-object System.Net.WebClient
+  $wc.Headers.Add("user-agent", "<%= user_agent_string %>")
   $proxy.Address = $env:http_proxy
   $wc.Proxy = $proxy
 
@@ -80,6 +81,7 @@ function Get-WebContentOnCore {
 
   $handler = New-Object System.Net.Http.HttpClientHandler
   $client = New-Object System.Net.Http.HttpClient($handler)
+  $client.DefaultRequestHeaders.UserAgent.ParseAdd("<%= user_agent_string %>")
   $client.Timeout = New-Object System.TimeSpan(0, 30, 0)
   $cancelTokenSource = [System.Threading.CancellationTokenSource]::new()
   $responseMsg = $client.GetAsync([System.Uri]::new($uri), $cancelTokenSource.Token)

--- a/lib/mixlib/install/util.rb
+++ b/lib/mixlib/install/util.rb
@@ -118,6 +118,17 @@ module Mixlib
           "sh -c '\n#{cmd}\n'"
         end
 
+        # Build the user-agent string
+        #
+        # @param name [Array] headers
+        # @return [String] generated user-agent string
+        def user_agent_string(headers)
+          require "mixlib/install/version"
+          user_agents = %W{mixlib-install/#{Mixlib::Install::VERSION}}
+          user_agents << headers
+          # Ensure that if the default user agent is aleady set it doesn't get duplicated
+          user_agents.flatten.compact.uniq.join(" ")
+        end
       end
     end
   end


### PR DESCRIPTION
We are adding user-agent headers to all download requests in the install scripts.

Added specs that verify the agent header templating for `Generator::Base` class

Need to verify the following function calls:
- [x] wget
```
$ wget -d --user-agent="User-Agent: testheader/1.2.3" https://packages.chef.io/files/stable/chef/12.15.19/ubuntu/14.04/chef_12.15.19-1_amd64.deb```
Setting --user-agent (useragent) to User-Agent: testheader/1.2.3

...

---request begin---
GET /files/stable/chef/12.15.19/ubuntu/14.04/chef_12.15.19-1_amd64.deb HTTP/1.1
User-Agent: User-Agent: testheader/1.2.3
```
- [x] curl
```
curl -v -sL -A "User-Agent: testheader/1.2.3" https://packages.chef.io/files/stable/chef/12.15.19/ubuntu/14.04/chef_12.15.19-1_amd64.deb  > foo

...

* Server certificate:
* 	 subject: C=US; ST=California; L=San Francisco; O=Fastly, Inc.; CN=g.ssl.fastly.net
* 	 start date: 2016-10-23 00:31:06 GMT
* 	 expire date: 2017-01-12 22:28:18 GMT
* 	 subjectAltName: packages.chef.io matched
* 	 issuer: C=BE; O=GlobalSign nv-sa; CN=GlobalSign Organization Validation CA - SHA256 - G2
* 	 SSL certificate verify ok.
> GET /files/stable/chef/12.15.19/ubuntu/14.04/chef_12.15.19-1_amd64.deb HTTP/1.1
> User-Agent: User-Agent: testheader/1.2.3

...
```
- [x] fetch

- [] perl - Not going update. See Scott's comment about Solaris 10 and LWP::UserAgent. LWP::Simple does not support headers. We'll see what we can do with that headers it passes if any.

- [x] python

- [x] webclient

- [x] httpclient

Signed-off-by: Patrick Wright <patrick@chef.io>

@schisamo 