### PR TITLE
Enable platform version compatibility mode for Windows artifacts

### DIFF
--- a/lib/mixlib/install/backend/base.rb
+++ b/lib/mixlib/install/backend/base.rb
@@ -94,18 +94,19 @@ module Mixlib
           artifacts.each do |a|
             return a if a.platform_version == options.platform_version
 
-            # We skip the artifacts produced for windows since their platform
-            # version is always set to 2008r2 which breaks our `to_f` comparison.
-            next if a.platform == "windows"
-
             # Calculate the closest compatible version.
             # For an artifact to be compatible it needs to be smaller than the
             # platform_version specified in options.
             # To find the closest compatible one we keep a max of the compatible
             # artifacts.
+
+            # Remove "r2" from artifacts produced for windows since platform
+            # versions with that ending break `to_f` comparisons.
+            current_platform_version = a.platform_version.chomp("r2").to_f
+
             if closest_compatible_artifact.nil? ||
-                (a.platform_version.to_f > closest_compatible_artifact.platform_version.to_f &&
-                  a.platform_version.to_f < options.platform_version.to_f )
+                (current_platform_version > closest_compatible_artifact.platform_version.to_f &&
+                  current_platform_version < options.platform_version.to_f )
               closest_compatible_artifact = a
             end
           end

--- a/lib/mixlib/install/cli.rb
+++ b/lib/mixlib/install/cli.rb
@@ -36,6 +36,12 @@ module Mixlib
         default: "x86_64",
         aliases: ["-a"],
         enum: Mixlib::Install::Options::SUPPORTED_ARCHITECTURES.map(&:to_s)
+      option :platform_version_compat,
+        desc: "Enable or disable platform version compatibility mode.
+This will match the closest earlier version if the passed version is unavailable.
+If no earlier version is found the earliest version available will be set.",
+        type: :boolean,
+        default: true
       option :url,
         desc: "Print download URL without downloading the file",
         type: :boolean
@@ -48,6 +54,7 @@ module Mixlib
           channel: options[:channel].to_sym,
           product_name: product_name,
           product_version: options[:version],
+          platform_version_compatibility_mode: options[:platform_version_compat],
         }
 
         # Set platform info or auto detect platform
@@ -59,6 +66,7 @@ module Mixlib
           mixlib_install_options[:platform_version] = options[:platform_version]
           mixlib_install_options[:architecture] = options[:architecture]
         else
+
           mixlib_install_options.merge!(Mixlib::Install.detect_platform)
         end
 

--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -61,6 +61,8 @@ module Mixlib
       def initialize(options)
         @options = options
 
+        map_windows_desktop_versions! if for_windows?
+
         validate!
       end
 
@@ -91,6 +93,7 @@ module Mixlib
       def for_ps1?
         platform == "windows" || shell_type == :ps1
       end
+      alias_method :for_windows?, :for_ps1?
 
       def latest_version?
         product_version.to_sym == :latest
@@ -173,6 +176,25 @@ Must be one of: #{SUPPORTED_SHELL_TYPES.join(", ")}
         end
 
         error
+      end
+
+      def map_windows_desktop_versions!
+        # This logic does not try to compare and determine proper versions based on conditions or ranges.
+        # These are here to improve UX for older desktop versions.
+        options[:platform_version] = case platform_version
+                                     when /^10/
+                                       "2016"
+                                     when /^6.3/, /^8.1/
+                                       "2012r2"
+                                     when /^6.2/, /^8/
+                                       "2012"
+                                     when /^6.1/, /^7/
+                                       "2008r2"
+                                     when /^6/
+                                       "2008"
+                                     else
+                                       platform_version
+                                     end
       end
     end
   end

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_PackageRouter_all_channels/for_a_version_of_windows_that_is_not_added_to_our_matrix/can_not_find_an_artifact.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_PackageRouter_all_channels/for_a_version_of_windows_that_is_not_added_to_our_matrix/can_not_find_an_artifact.yml
@@ -1,0 +1,1280 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/build/chefdk
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/vnd.org.jfrog.build.BuildsByName+json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 376907d2051c93f6f9f5ef88c639f1347e2ba099460d7e9d81c2710f8719886c
+      Content-Length:
+      - '1929'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:42:22 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3135-SJC, cache-lax8633-LAX
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1479490942.812522,VS0,VE68
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "buildsNumbers" : [ {
+            "uri" : "/1.1.1",
+            "started" : "2016-11-17T20:51:34.911+0000"
+          }, {
+            "uri" : "/0.20.1",
+            "started" : "2016-10-20T19:26:41.591+0000"
+          }, {
+            "uri" : "/0.18.30",
+            "started" : "2016-09-28T01:33:23.057+0000"
+          }, {
+            "uri" : "/0.12.0",
+            "started" : "2016-03-18T01:35:32.234+0000"
+          }, {
+            "uri" : "/0.20.4",
+            "started" : "2016-11-02T04:59:55.998+0000"
+          }, {
+            "uri" : "/1.0.5",
+            "started" : "2016-11-16T21:19:10.561+0000"
+          }, {
+            "uri" : "/0.11.2",
+            "started" : "2016-02-23T00:07:53.207+0000"
+          }, {
+            "uri" : "/0.18.26",
+            "started" : "2016-09-22T05:22:47.621+0000"
+          }, {
+            "uri" : "/0.15.15",
+            "started" : "2016-06-17T03:07:07.697+0000"
+          }, {
+            "uri" : "/0.10.0",
+            "started" : "2015-11-07T00:29:08.746+0000"
+          }, {
+            "uri" : "/0.8.1",
+            "started" : "2015-10-01T05:19:57.291+0000"
+          }, {
+            "uri" : "/1.0.3",
+            "started" : "2016-11-14T22:57:34.077+0000"
+          }, {
+            "uri" : "/0.19.6",
+            "started" : "2016-10-17T20:31:57.428+0000"
+          }, {
+            "uri" : "/0.11.0",
+            "started" : "2016-02-12T19:19:42.650+0000"
+          }, {
+            "uri" : "/1.0.4",
+            "started" : "2016-11-15T18:34:18.631+0000"
+          }, {
+            "uri" : "/0.16.28",
+            "started" : "2016-07-16T00:14:37.375+0000"
+          }, {
+            "uri" : "/0.13.21",
+            "started" : "2016-04-15T21:22:13.827+0000"
+          }, {
+            "uri" : "/0.9.0",
+            "started" : "2015-10-08T06:53:55.080+0000"
+          }, {
+            "uri" : "/0.19.7",
+            "started" : "2016-10-19T21:27:26.078+0000"
+          }, {
+            "uri" : "/0.15.16",
+            "started" : "2016-07-01T20:27:36.981+0000"
+          }, {
+            "uri" : "/0.8.0",
+            "started" : "2015-09-23T21:55:13.990+0000"
+          }, {
+            "uri" : "/0.14.25",
+            "started" : "2016-05-17T02:27:12.784+0000"
+          }, {
+            "uri" : "/0.7.0",
+            "started" : "2015-08-14T00:06:00.484+0000"
+          }, {
+            "uri" : "/0.17.17",
+            "started" : "2016-08-15T18:32:56.846+0000"
+          } ],
+          "uri" : "https://packages.chef.io/api/build/chefdk"
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:42:22 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.1.1/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 63893ee770b7170661167710947c4e43479e69b8bd4379cc2caca1b1bc8d910d
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:42:23 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3143-SJC, cache-lax8630-LAX
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1479490942.969506,VS0,VE54
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:42:23 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.0.5/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - fc1c08b8741a8b8238e161dff13582c9b6904ba3a6ef14cb664e29dcfd81822f
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:42:23 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3141-SJC, cache-lax8637-LAX
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1479490943.113017,VS0,VE54
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:42:23 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.0.4/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 9b2864f185780c2b88321031cf36f67169d03566734e3c5a058dc5aceb98916b
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:42:23 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3145-SJC, cache-lax8624-LAX
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1479490943.256783,VS0,VE150
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:42:23 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.0.3/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 3fd196eec7203f49974d5bb669f6404f1c8ee19905f47f73bdf2df22b9fb7242
+      Content-Length:
+      - '25423'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:42:23 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3123-SJC, cache-lax8641-LAX
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1479490943.494734,VS0,VE89
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/ubuntu/16.04",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "16.04"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/el/6",
+          "name" : "chefdk-1.0.3-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "cc815e2ff718773b506ac5a9e8f1c1e9dca0ffa73f7d600bf337d39b558c6a79"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "57c44884d0d1f3d25b97511ec0b1288c"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "sha512",
+            "value" : "401e32d4246b5439e355407975ed906ff3e020f8938a95920908b19ea84aa17dbd5bb4d5d7f06b97e7c4ffeef2041443c99f8a7f62aa16af89b5f7b7334e74d1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "sha256",
+            "value" : "cc815e2ff718773b506ac5a9e8f1c1e9dca0ffa73f7d600bf337d39b558c6a79"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a6c7a4adcd3dff347bdb541df5e98d6ecc790afc"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "401e32d4246b5439e355407975ed906ff3e020f8938a95920908b19ea84aa17dbd5bb4d5d7f06b97e7c4ffeef2041443c99f8a7f62aa16af89b5f7b7334e74d1"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "sha1",
+            "value" : "a6c7a4adcd3dff347bdb541df5e98d6ecc790afc"
+          }, {
+            "key" : "md5",
+            "value" : "57c44884d0d1f3d25b97511ec0b1288c"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/windows/2008r2",
+          "name" : "chefdk-1.0.3-1-x86.msi",
+          "properties" : [ {
+            "key" : "sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2008r2"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/ubuntu/12.04",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/debian/7",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.10",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.10"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/el/7",
+          "name" : "chefdk-1.0.3-1.el7.x86_64.rpm",
+          "properties" : [ {
+            "key" : "delivery.change"
+          }, {
+            "key" : "md5",
+            "value" : "23dd34eccea0e02bd4624bbade29e172"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha256",
+            "value" : "dd288b375a44078bed04cce744b5f7e2b50c8292be595db4d496a97ae51b6565"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd288b375a44078bed04cce744b5f7e2b50c8292be595db4d496a97ae51b6565"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "sha1",
+            "value" : "bb64d175868d1861b0e98be1ce74c0e550dc7148"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "23dd34eccea0e02bd4624bbade29e172"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha512",
+            "value" : "8f260799fb990f71f591a6b731659cdb254df466beb20a721542db93508f5d92bc6fa38b16b21629b735e8ad6eae291659ea8c46ea186c41b8a64b4379f12dd2"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "8f260799fb990f71f591a6b731659cdb254df466beb20a721542db93508f5d92bc6fa38b16b21629b735e8ad6eae291659ea8c46ea186c41b8a64b4379f12dd2"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "bb64d175868d1861b0e98be1ce74c0e550dc7148"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/debian/8",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "8"
+          }, {
+            "key" : "sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/debian/6",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.11",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.11"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.12",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.12"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/windows/2012r2",
+          "name" : "chefdk-1.0.3-1-x86.msi",
+          "properties" : [ {
+            "key" : "delivery.change"
+          }, {
+            "key" : "sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012r2"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/ubuntu/14.04",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.9",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.9"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/windows/2012",
+          "name" : "chefdk-1.0.3-1-x86.msi",
+          "properties" : [ {
+            "key" : "sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 15,
+          "total" : 15
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:42:23 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_PackageRouter_all_channels/for_a_version_of_windows_that_is_not_added_to_our_matrix/when_product_version_compat_mode_is_set/finds_an_artifact.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_PackageRouter_all_channels/for_a_version_of_windows_that_is_not_added_to_our_matrix/when_product_version_compat_mode_is_set/finds_an_artifact.yml
@@ -1,0 +1,1280 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/build/chefdk
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/vnd.org.jfrog.build.BuildsByName+json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 376907d2051c93f6f9f5ef88c639f1347e2ba099460d7e9d81c2710f8719886c
+      Content-Length:
+      - '1929'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:42:23 GMT
+      Age:
+      - '1'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3135-SJC, cache-lax8635-LAX
+      X-Cache:
+      - MISS, HIT
+      X-Cache-Hits:
+      - 0, 1
+      X-Timer:
+      - S1479490943.712202,VS0,VE0
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "buildsNumbers" : [ {
+            "uri" : "/1.1.1",
+            "started" : "2016-11-17T20:51:34.911+0000"
+          }, {
+            "uri" : "/0.20.1",
+            "started" : "2016-10-20T19:26:41.591+0000"
+          }, {
+            "uri" : "/0.18.30",
+            "started" : "2016-09-28T01:33:23.057+0000"
+          }, {
+            "uri" : "/0.12.0",
+            "started" : "2016-03-18T01:35:32.234+0000"
+          }, {
+            "uri" : "/0.20.4",
+            "started" : "2016-11-02T04:59:55.998+0000"
+          }, {
+            "uri" : "/1.0.5",
+            "started" : "2016-11-16T21:19:10.561+0000"
+          }, {
+            "uri" : "/0.11.2",
+            "started" : "2016-02-23T00:07:53.207+0000"
+          }, {
+            "uri" : "/0.18.26",
+            "started" : "2016-09-22T05:22:47.621+0000"
+          }, {
+            "uri" : "/0.15.15",
+            "started" : "2016-06-17T03:07:07.697+0000"
+          }, {
+            "uri" : "/0.10.0",
+            "started" : "2015-11-07T00:29:08.746+0000"
+          }, {
+            "uri" : "/0.8.1",
+            "started" : "2015-10-01T05:19:57.291+0000"
+          }, {
+            "uri" : "/1.0.3",
+            "started" : "2016-11-14T22:57:34.077+0000"
+          }, {
+            "uri" : "/0.19.6",
+            "started" : "2016-10-17T20:31:57.428+0000"
+          }, {
+            "uri" : "/0.11.0",
+            "started" : "2016-02-12T19:19:42.650+0000"
+          }, {
+            "uri" : "/1.0.4",
+            "started" : "2016-11-15T18:34:18.631+0000"
+          }, {
+            "uri" : "/0.16.28",
+            "started" : "2016-07-16T00:14:37.375+0000"
+          }, {
+            "uri" : "/0.13.21",
+            "started" : "2016-04-15T21:22:13.827+0000"
+          }, {
+            "uri" : "/0.9.0",
+            "started" : "2015-10-08T06:53:55.080+0000"
+          }, {
+            "uri" : "/0.19.7",
+            "started" : "2016-10-19T21:27:26.078+0000"
+          }, {
+            "uri" : "/0.15.16",
+            "started" : "2016-07-01T20:27:36.981+0000"
+          }, {
+            "uri" : "/0.8.0",
+            "started" : "2015-09-23T21:55:13.990+0000"
+          }, {
+            "uri" : "/0.14.25",
+            "started" : "2016-05-17T02:27:12.784+0000"
+          }, {
+            "uri" : "/0.7.0",
+            "started" : "2015-08-14T00:06:00.484+0000"
+          }, {
+            "uri" : "/0.17.17",
+            "started" : "2016-08-15T18:32:56.846+0000"
+          } ],
+          "uri" : "https://packages.chef.io/api/build/chefdk"
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:42:23 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.1.1/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 63893ee770b7170661167710947c4e43479e69b8bd4379cc2caca1b1bc8d910d
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:42:23 GMT
+      Age:
+      - '1'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3143-SJC, cache-lax8627-LAX
+      X-Cache:
+      - MISS, HIT
+      X-Cache-Hits:
+      - 0, 1
+      X-Timer:
+      - S1479490943.795752,VS0,VE0
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:42:23 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.0.5/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - fc1c08b8741a8b8238e161dff13582c9b6904ba3a6ef14cb664e29dcfd81822f
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:42:23 GMT
+      Age:
+      - '1'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3141-SJC, cache-lax8641-LAX
+      X-Cache:
+      - MISS, HIT
+      X-Cache-Hits:
+      - 0, 1
+      X-Timer:
+      - S1479490943.882605,VS0,VE0
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:42:23 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.0.4/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 9b2864f185780c2b88321031cf36f67169d03566734e3c5a058dc5aceb98916b
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:42:23 GMT
+      Age:
+      - '1'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3145-SJC, cache-lax8620-LAX
+      X-Cache:
+      - MISS, HIT
+      X-Cache-Hits:
+      - 0, 1
+      X-Timer:
+      - S1479490943.975393,VS0,VE0
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:42:24 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.0.3/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 3fd196eec7203f49974d5bb669f6404f1c8ee19905f47f73bdf2df22b9fb7242
+      Content-Length:
+      - '25423'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:42:24 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3123-SJC, cache-lax8623-LAX
+      X-Cache:
+      - MISS, HIT
+      X-Cache-Hits:
+      - 0, 1
+      X-Timer:
+      - S1479490944.063248,VS0,VE0
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/ubuntu/16.04",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "16.04"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/el/6",
+          "name" : "chefdk-1.0.3-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "cc815e2ff718773b506ac5a9e8f1c1e9dca0ffa73f7d600bf337d39b558c6a79"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "57c44884d0d1f3d25b97511ec0b1288c"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "sha512",
+            "value" : "401e32d4246b5439e355407975ed906ff3e020f8938a95920908b19ea84aa17dbd5bb4d5d7f06b97e7c4ffeef2041443c99f8a7f62aa16af89b5f7b7334e74d1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "sha256",
+            "value" : "cc815e2ff718773b506ac5a9e8f1c1e9dca0ffa73f7d600bf337d39b558c6a79"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a6c7a4adcd3dff347bdb541df5e98d6ecc790afc"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "401e32d4246b5439e355407975ed906ff3e020f8938a95920908b19ea84aa17dbd5bb4d5d7f06b97e7c4ffeef2041443c99f8a7f62aa16af89b5f7b7334e74d1"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "sha1",
+            "value" : "a6c7a4adcd3dff347bdb541df5e98d6ecc790afc"
+          }, {
+            "key" : "md5",
+            "value" : "57c44884d0d1f3d25b97511ec0b1288c"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/windows/2008r2",
+          "name" : "chefdk-1.0.3-1-x86.msi",
+          "properties" : [ {
+            "key" : "sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2008r2"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/ubuntu/12.04",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/debian/7",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.10",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.10"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/el/7",
+          "name" : "chefdk-1.0.3-1.el7.x86_64.rpm",
+          "properties" : [ {
+            "key" : "delivery.change"
+          }, {
+            "key" : "md5",
+            "value" : "23dd34eccea0e02bd4624bbade29e172"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha256",
+            "value" : "dd288b375a44078bed04cce744b5f7e2b50c8292be595db4d496a97ae51b6565"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd288b375a44078bed04cce744b5f7e2b50c8292be595db4d496a97ae51b6565"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "sha1",
+            "value" : "bb64d175868d1861b0e98be1ce74c0e550dc7148"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "23dd34eccea0e02bd4624bbade29e172"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha512",
+            "value" : "8f260799fb990f71f591a6b731659cdb254df466beb20a721542db93508f5d92bc6fa38b16b21629b735e8ad6eae291659ea8c46ea186c41b8a64b4379f12dd2"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "8f260799fb990f71f591a6b731659cdb254df466beb20a721542db93508f5d92bc6fa38b16b21629b735e8ad6eae291659ea8c46ea186c41b8a64b4379f12dd2"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "bb64d175868d1861b0e98be1ce74c0e550dc7148"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/debian/8",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "8"
+          }, {
+            "key" : "sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/debian/6",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.11",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.11"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.12",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.12"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/windows/2012r2",
+          "name" : "chefdk-1.0.3-1-x86.msi",
+          "properties" : [ {
+            "key" : "delivery.change"
+          }, {
+            "key" : "sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012r2"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/ubuntu/14.04",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.9",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.9"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/windows/2012",
+          "name" : "chefdk-1.0.3-1-x86.msi",
+          "properties" : [ {
+            "key" : "sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 15,
+          "total" : 15
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:42:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_PackageRouter_all_channels/for_a_version_of_windows_that_is_not_added_to_our_matrix/when_product_version_compat_mode_is_set/when_a_desktop_version_is_set/finds_an_artifact.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_PackageRouter_all_channels/for_a_version_of_windows_that_is_not_added_to_our_matrix/when_product_version_compat_mode_is_set/when_a_desktop_version_is_set/finds_an_artifact.yml
@@ -1,0 +1,1410 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/build/chefdk
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/vnd.org.jfrog.build.BuildsByName+json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 376907d2051c93f6f9f5ef88c639f1347e2ba099460d7e9d81c2710f8719886c
+      Content-Length:
+      - '2081'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 19:43:56 GMT
+      Age:
+      - '79'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3149-SJC, cache-lax8632-LAX
+      X-Cache:
+      - HIT, MISS
+      X-Cache-Hits:
+      - 1, 0
+      X-Timer:
+      - S1479498236.616035,VS0,VE8
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "buildsNumbers" : [ {
+            "uri" : "/0.18.30",
+            "started" : "2016-09-28T01:33:23.057+0000"
+          }, {
+            "uri" : "/0.20.4",
+            "started" : "2016-11-02T04:59:55.998+0000"
+          }, {
+            "uri" : "/0.8.1",
+            "started" : "2015-10-01T05:19:57.291+0000"
+          }, {
+            "uri" : "/1.0.3",
+            "started" : "2016-11-14T22:57:34.077+0000"
+          }, {
+            "uri" : "/0.19.6",
+            "started" : "2016-10-17T20:31:57.428+0000"
+          }, {
+            "uri" : "/0.11.0",
+            "started" : "2016-02-12T19:19:42.650+0000"
+          }, {
+            "uri" : "/1.0.4",
+            "started" : "2016-11-15T18:34:18.631+0000"
+          }, {
+            "uri" : "/0.9.0",
+            "started" : "2015-10-08T06:53:55.080+0000"
+          }, {
+            "uri" : "/0.19.7",
+            "started" : "2016-10-19T21:27:26.078+0000"
+          }, {
+            "uri" : "/0.15.16",
+            "started" : "2016-07-01T20:27:36.981+0000"
+          }, {
+            "uri" : "/0.8.0",
+            "started" : "2015-09-23T21:55:13.990+0000"
+          }, {
+            "uri" : "/0.7.0",
+            "started" : "2015-08-14T00:06:00.484+0000"
+          }, {
+            "uri" : "/1.1.2",
+            "started" : "2016-11-18T17:50:59.266+0000"
+          }, {
+            "uri" : "/1.1.1",
+            "started" : "2016-11-17T20:51:34.911+0000"
+          }, {
+            "uri" : "/0.20.1",
+            "started" : "2016-10-20T19:26:41.591+0000"
+          }, {
+            "uri" : "/0.12.0",
+            "started" : "2016-03-18T01:35:32.234+0000"
+          }, {
+            "uri" : "/1.0.5",
+            "started" : "2016-11-16T21:19:10.561+0000"
+          }, {
+            "uri" : "/0.11.2",
+            "started" : "2016-02-23T00:07:53.207+0000"
+          }, {
+            "uri" : "/0.18.26",
+            "started" : "2016-09-22T05:22:47.621+0000"
+          }, {
+            "uri" : "/0.15.15",
+            "started" : "2016-06-17T03:07:07.697+0000"
+          }, {
+            "uri" : "/0.10.0",
+            "started" : "2015-11-07T00:29:08.746+0000"
+          }, {
+            "uri" : "/0.16.28",
+            "started" : "2016-07-16T00:14:37.375+0000"
+          }, {
+            "uri" : "/0.13.21",
+            "started" : "2016-04-15T21:22:13.827+0000"
+          }, {
+            "uri" : "/0.14.25",
+            "started" : "2016-05-17T02:27:12.784+0000"
+          }, {
+            "uri" : "/0.17.17",
+            "started" : "2016-08-15T18:32:56.846+0000"
+          }, {
+            "uri" : "/1.1.3",
+            "started" : "2016-11-18T18:30:47.966+0000"
+          } ],
+          "uri" : "https://packages.chef.io/api/build/chefdk"
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 19:43:56 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.1.3/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - fe9adb4256a003844f6b44419c6ab764c346f2a0f4e7bab4c9cb1cb3e1566468
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 19:43:56 GMT
+      Age:
+      - '79'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3133-SJC, cache-lax8624-LAX
+      X-Cache:
+      - HIT, MISS
+      X-Cache-Hits:
+      - 1, 0
+      X-Timer:
+      - S1479498236.709148,VS0,VE8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 19:43:56 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.1.2/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - d5a20c7593167f46ebf42a2a5907d43786e970f6240f266131cbb5baab427c30
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 19:43:56 GMT
+      Age:
+      - '79'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3130-SJC, cache-lax8651-LAX
+      X-Cache:
+      - HIT, MISS
+      X-Cache-Hits:
+      - 1, 0
+      X-Timer:
+      - S1479498236.820242,VS0,VE8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 19:43:57 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.1.1/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 63893ee770b7170661167710947c4e43479e69b8bd4379cc2caca1b1bc8d910d
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 19:43:56 GMT
+      Age:
+      - '79'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3133-SJC, cache-lax8631-LAX
+      X-Cache:
+      - HIT, MISS
+      X-Cache-Hits:
+      - 1, 0
+      X-Timer:
+      - S1479498236.921782,VS0,VE9
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 19:43:57 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.0.5/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - fc1c08b8741a8b8238e161dff13582c9b6904ba3a6ef14cb664e29dcfd81822f
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 19:43:57 GMT
+      Age:
+      - '79'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3147-SJC, cache-lax8623-LAX
+      X-Cache:
+      - HIT, MISS
+      X-Cache-Hits:
+      - 1, 0
+      X-Timer:
+      - S1479498237.009525,VS0,VE9
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 19:43:57 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.0.4/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 9b2864f185780c2b88321031cf36f67169d03566734e3c5a058dc5aceb98916b
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 19:43:57 GMT
+      Age:
+      - '79'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3122-SJC, cache-lax8643-LAX
+      X-Cache:
+      - HIT, MISS
+      X-Cache-Hits:
+      - 1, 0
+      X-Timer:
+      - S1479498237.103729,VS0,VE8
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 19:43:57 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.0.3/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 3fd196eec7203f49974d5bb669f6404f1c8ee19905f47f73bdf2df22b9fb7242
+      Content-Length:
+      - '25423'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 19:43:57 GMT
+      Age:
+      - '195'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3130-SJC, cache-lax8630-LAX
+      X-Cache:
+      - MISS, HIT
+      X-Cache-Hits:
+      - 0, 2
+      X-Timer:
+      - S1479498237.196765,VS0,VE0
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/ubuntu/16.04",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "16.04"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/el/6",
+          "name" : "chefdk-1.0.3-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "cc815e2ff718773b506ac5a9e8f1c1e9dca0ffa73f7d600bf337d39b558c6a79"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "57c44884d0d1f3d25b97511ec0b1288c"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "sha512",
+            "value" : "401e32d4246b5439e355407975ed906ff3e020f8938a95920908b19ea84aa17dbd5bb4d5d7f06b97e7c4ffeef2041443c99f8a7f62aa16af89b5f7b7334e74d1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "sha256",
+            "value" : "cc815e2ff718773b506ac5a9e8f1c1e9dca0ffa73f7d600bf337d39b558c6a79"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a6c7a4adcd3dff347bdb541df5e98d6ecc790afc"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "401e32d4246b5439e355407975ed906ff3e020f8938a95920908b19ea84aa17dbd5bb4d5d7f06b97e7c4ffeef2041443c99f8a7f62aa16af89b5f7b7334e74d1"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "sha1",
+            "value" : "a6c7a4adcd3dff347bdb541df5e98d6ecc790afc"
+          }, {
+            "key" : "md5",
+            "value" : "57c44884d0d1f3d25b97511ec0b1288c"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/windows/2008r2",
+          "name" : "chefdk-1.0.3-1-x86.msi",
+          "properties" : [ {
+            "key" : "sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2008r2"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/ubuntu/12.04",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/debian/7",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.10",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.10"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/el/7",
+          "name" : "chefdk-1.0.3-1.el7.x86_64.rpm",
+          "properties" : [ {
+            "key" : "delivery.change"
+          }, {
+            "key" : "md5",
+            "value" : "23dd34eccea0e02bd4624bbade29e172"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha256",
+            "value" : "dd288b375a44078bed04cce744b5f7e2b50c8292be595db4d496a97ae51b6565"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd288b375a44078bed04cce744b5f7e2b50c8292be595db4d496a97ae51b6565"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "sha1",
+            "value" : "bb64d175868d1861b0e98be1ce74c0e550dc7148"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "23dd34eccea0e02bd4624bbade29e172"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha512",
+            "value" : "8f260799fb990f71f591a6b731659cdb254df466beb20a721542db93508f5d92bc6fa38b16b21629b735e8ad6eae291659ea8c46ea186c41b8a64b4379f12dd2"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "8f260799fb990f71f591a6b731659cdb254df466beb20a721542db93508f5d92bc6fa38b16b21629b735e8ad6eae291659ea8c46ea186c41b8a64b4379f12dd2"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "bb64d175868d1861b0e98be1ce74c0e550dc7148"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/debian/8",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "8"
+          }, {
+            "key" : "sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/debian/6",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.11",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.11"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.12",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.12"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/windows/2012r2",
+          "name" : "chefdk-1.0.3-1-x86.msi",
+          "properties" : [ {
+            "key" : "delivery.change"
+          }, {
+            "key" : "sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012r2"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/ubuntu/14.04",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.9",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.9"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/windows/2012",
+          "name" : "chefdk-1.0.3-1-x86.msi",
+          "properties" : [ {
+            "key" : "sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 15,
+          "total" : 15
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 19:43:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_PackageRouter_all_channels/for_a_version_of_windows_that_is_not_added_to_our_matrix/when_product_version_compat_mode_is_set/when_version_ends_with_r2/finds_an_artifact.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_PackageRouter_all_channels/for_a_version_of_windows_that_is_not_added_to_our_matrix/when_product_version_compat_mode_is_set/when_version_ends_with_r2/finds_an_artifact.yml
@@ -1,0 +1,1345 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/build/chefdk
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/vnd.org.jfrog.build.BuildsByName+json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 376907d2051c93f6f9f5ef88c639f1347e2ba099460d7e9d81c2710f8719886c
+      Content-Length:
+      - '2005'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:57:13 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3146-SJC, cache-lax8640-LAX
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1479491833.816867,VS0,VE63
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "buildsNumbers" : [ {
+            "uri" : "/0.18.30",
+            "started" : "2016-09-28T01:33:23.057+0000"
+          }, {
+            "uri" : "/0.20.4",
+            "started" : "2016-11-02T04:59:55.998+0000"
+          }, {
+            "uri" : "/0.8.1",
+            "started" : "2015-10-01T05:19:57.291+0000"
+          }, {
+            "uri" : "/1.0.3",
+            "started" : "2016-11-14T22:57:34.077+0000"
+          }, {
+            "uri" : "/0.19.6",
+            "started" : "2016-10-17T20:31:57.428+0000"
+          }, {
+            "uri" : "/0.11.0",
+            "started" : "2016-02-12T19:19:42.650+0000"
+          }, {
+            "uri" : "/1.0.4",
+            "started" : "2016-11-15T18:34:18.631+0000"
+          }, {
+            "uri" : "/0.9.0",
+            "started" : "2015-10-08T06:53:55.080+0000"
+          }, {
+            "uri" : "/0.19.7",
+            "started" : "2016-10-19T21:27:26.078+0000"
+          }, {
+            "uri" : "/0.15.16",
+            "started" : "2016-07-01T20:27:36.981+0000"
+          }, {
+            "uri" : "/0.8.0",
+            "started" : "2015-09-23T21:55:13.990+0000"
+          }, {
+            "uri" : "/0.7.0",
+            "started" : "2015-08-14T00:06:00.484+0000"
+          }, {
+            "uri" : "/1.1.2",
+            "started" : "2016-11-18T17:50:59.266+0000"
+          }, {
+            "uri" : "/1.1.1",
+            "started" : "2016-11-17T20:51:34.911+0000"
+          }, {
+            "uri" : "/0.20.1",
+            "started" : "2016-10-20T19:26:41.591+0000"
+          }, {
+            "uri" : "/0.12.0",
+            "started" : "2016-03-18T01:35:32.234+0000"
+          }, {
+            "uri" : "/1.0.5",
+            "started" : "2016-11-16T21:19:10.561+0000"
+          }, {
+            "uri" : "/0.11.2",
+            "started" : "2016-02-23T00:07:53.207+0000"
+          }, {
+            "uri" : "/0.18.26",
+            "started" : "2016-09-22T05:22:47.621+0000"
+          }, {
+            "uri" : "/0.15.15",
+            "started" : "2016-06-17T03:07:07.697+0000"
+          }, {
+            "uri" : "/0.10.0",
+            "started" : "2015-11-07T00:29:08.746+0000"
+          }, {
+            "uri" : "/0.16.28",
+            "started" : "2016-07-16T00:14:37.375+0000"
+          }, {
+            "uri" : "/0.13.21",
+            "started" : "2016-04-15T21:22:13.827+0000"
+          }, {
+            "uri" : "/0.14.25",
+            "started" : "2016-05-17T02:27:12.784+0000"
+          }, {
+            "uri" : "/0.17.17",
+            "started" : "2016-08-15T18:32:56.846+0000"
+          } ],
+          "uri" : "https://packages.chef.io/api/build/chefdk"
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:57:13 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.1.2/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - d5a20c7593167f46ebf42a2a5907d43786e970f6240f266131cbb5baab427c30
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:57:14 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3121-SJC, cache-lax8642-LAX
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1479491833.979108,VS0,VE161
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:57:14 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.1.1/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 63893ee770b7170661167710947c4e43479e69b8bd4379cc2caca1b1bc8d910d
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:57:14 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3137-SJC, cache-lax8631-LAX
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1479491834.361328,VS0,VE130
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:57:14 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.0.5/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - fc1c08b8741a8b8238e161dff13582c9b6904ba3a6ef14cb664e29dcfd81822f
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:57:14 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3130-SJC, cache-lax8623-LAX
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1479491834.581078,VS0,VE111
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:57:14 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.0.4/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 9b2864f185780c2b88321031cf36f67169d03566734e3c5a058dc5aceb98916b
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:57:14 GMT
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3143-SJC, cache-lax8644-LAX
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Timer:
+      - S1479491834.779460,VS0,VE117
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:57:14 GMT
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/stable/chefdk/1.0.3/artifacts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.6
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 3c031508623683e4:-49c0c854:15826b5bd31:-7f69
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 3fd196eec7203f49974d5bb669f6404f1c8ee19905f47f73bdf2df22b9fb7242
+      Content-Length:
+      - '25423'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 18 Nov 2016 17:57:14 GMT
+      Age:
+      - '109'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3142-SJC, cache-lax8643-LAX
+      X-Cache:
+      - HIT, MISS
+      X-Cache-Hits:
+      - 1, 0
+      X-Timer:
+      - S1479491834.980086,VS0,VE10
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [ {
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/ubuntu/16.04",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "16.04"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/el/6",
+          "name" : "chefdk-1.0.3-1.el6.x86_64.rpm",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "cc815e2ff718773b506ac5a9e8f1c1e9dca0ffa73f7d600bf337d39b558c6a79"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "57c44884d0d1f3d25b97511ec0b1288c"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "sha512",
+            "value" : "401e32d4246b5439e355407975ed906ff3e020f8938a95920908b19ea84aa17dbd5bb4d5d7f06b97e7c4ffeef2041443c99f8a7f62aa16af89b5f7b7334e74d1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "sha256",
+            "value" : "cc815e2ff718773b506ac5a9e8f1c1e9dca0ffa73f7d600bf337d39b558c6a79"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a6c7a4adcd3dff347bdb541df5e98d6ecc790afc"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "401e32d4246b5439e355407975ed906ff3e020f8938a95920908b19ea84aa17dbd5bb4d5d7f06b97e7c4ffeef2041443c99f8a7f62aa16af89b5f7b7334e74d1"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "sha1",
+            "value" : "a6c7a4adcd3dff347bdb541df5e98d6ecc790afc"
+          }, {
+            "key" : "md5",
+            "value" : "57c44884d0d1f3d25b97511ec0b1288c"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/windows/2008r2",
+          "name" : "chefdk-1.0.3-1-x86.msi",
+          "properties" : [ {
+            "key" : "sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2008r2"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/ubuntu/12.04",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "12.04"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/debian/7",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.10",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.10"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/el/7",
+          "name" : "chefdk-1.0.3-1.el7.x86_64.rpm",
+          "properties" : [ {
+            "key" : "delivery.change"
+          }, {
+            "key" : "md5",
+            "value" : "23dd34eccea0e02bd4624bbade29e172"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha256",
+            "value" : "dd288b375a44078bed04cce744b5f7e2b50c8292be595db4d496a97ae51b6565"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "dd288b375a44078bed04cce744b5f7e2b50c8292be595db4d496a97ae51b6565"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "7"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "sha1",
+            "value" : "bb64d175868d1861b0e98be1ce74c0e550dc7148"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "23dd34eccea0e02bd4624bbade29e172"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "el"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha512",
+            "value" : "8f260799fb990f71f591a6b731659cdb254df466beb20a721542db93508f5d92bc6fa38b16b21629b735e8ad6eae291659ea8c46ea186c41b8a64b4379f12dd2"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "8f260799fb990f71f591a6b731659cdb254df466beb20a721542db93508f5d92bc6fa38b16b21629b735e8ad6eae291659ea8c46ea186c41b8a64b4379f12dd2"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "bb64d175868d1861b0e98be1ce74c0e550dc7148"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/debian/8",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "8"
+          }, {
+            "key" : "sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/debian/6",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "debian"
+          }, {
+            "key" : "sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "313ced76f9b639fcf7eab68f734a3e50"
+          }, {
+            "key" : "sha256",
+            "value" : "07df91caf2bc71e56edd429c18dc75fc44f84e06f0447397176916b322c93252"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "6"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "a645de52d88b264636e50926ec5d30c8452ce91b"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "052866c31ce0bb1ebcbb62c5f3e4a6c4c96f784fa502333de33b19059d0db054b0b7bd367dd31e347431cdf389ccb4a337f4e424274bb5b6ab9dcf5a8718afb5"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.11",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.11"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.12",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.12"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/windows/2012r2",
+          "name" : "chefdk-1.0.3-1-x86.msi",
+          "properties" : [ {
+            "key" : "delivery.change"
+          }, {
+            "key" : "sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012r2"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/ubuntu/14.04",
+          "name" : "chefdk_1.0.3-1_amd64.deb",
+          "properties" : [ {
+            "key" : "omnibus.md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "ca3734ac4af5a6d92585d290d6fd0d50d974d5afc4701290afb0c28b38c623014a700658f0b0cb6941c4d99caad10e3a652917101ddec708a879098b9f66239c"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "14.04"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "368bb1b4f072937bd630100569c50cc57c45895eeba19bc44dffed9e259cc9a1"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "md5",
+            "value" : "6fcdc8eed1ce8e0408c072439a87c932"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "sha1",
+            "value" : "f0c9f4e1c1ddec0af640bc448cc495f46c112ef6"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "ubuntu"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/mac_os_x/10.9",
+          "name" : "chefdk-1.0.3-1.dmg",
+          "properties" : [ {
+            "key" : "omnibus.sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "sha1",
+            "value" : "0b2e1574a0d29dd91e00b685e50dff4c0e690b34"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "c22d545605ffea491035b026ba9abdcea48cdc67a58d87217bea6113fd99f22f"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "x86_64"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "mac_os_x"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "30f09c9225688bb6df88f8937537d61f6f84dd541854510ea3214f451cdf71941a4aa193244c85e0b6f1e567e3aef4a5ffdca65ac7e83376f0be20768aa38f7a"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "fa57cb1fd997547d17c787e86a34b582"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "10.9"
+          } ]
+        },{
+          "repo" : "omnibus-stable-local",
+          "path" : "com/getchef/chefdk/1.0.3/windows/2012",
+          "name" : "chefdk-1.0.3-1-x86.msi",
+          "properties" : [ {
+            "key" : "sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "omnibus.platform",
+            "value" : "windows"
+          }, {
+            "key" : "omnibus.sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          }, {
+            "key" : "omnibus.md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "omnibus.platform_version",
+            "value" : "2012"
+          }, {
+            "key" : "omnibus.version",
+            "value" : "1.0.3"
+          }, {
+            "key" : "sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "omnibus.architecture",
+            "value" : "i386"
+          }, {
+            "key" : "omnibus.iteration",
+            "value" : "1"
+          }, {
+            "key" : "omnibus.license",
+            "value" : "Apache-2.0"
+          }, {
+            "key" : "omnibus.sha1",
+            "value" : "3b19e68f1aa738b3c6f7a1173083d63ee85c76d0"
+          }, {
+            "key" : "md5",
+            "value" : "dab9b416ada93ba3cccf885eebd5cae0"
+          }, {
+            "key" : "build.name",
+            "value" : "chefdk"
+          }, {
+            "key" : "omnibus.project",
+            "value" : "chefdk"
+          }, {
+            "key" : "delivery.sha"
+          }, {
+            "key" : "build.number",
+            "value" : "1.0.3"
+          }, {
+            "key" : "delivery.change"
+          }, {
+            "key" : "omnibus.sha512",
+            "value" : "531e54bac045785194b6d06bfb08adf730355ed47aee54dcafe1ff71655af0e3b04ab4e9a77b001cf9c1cac8654bc4831407199d6ad9624dc0e8c1966bb986d4"
+          }, {
+            "key" : "sha256",
+            "value" : "b9fe94a583f83ecadb773edb94358353e4744693b3cf7ab51d4420a10404ba5d"
+          } ]
+        } ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 15,
+          "total" : 15
+        }
+        }
+    http_version: 
+  recorded_at: Fri, 18 Nov 2016 17:57:15 GMT
+recorded_with: VCR 3.0.3

--- a/spec/functional/mixlib/install/cli_spec.rb
+++ b/spec/functional/mixlib/install/cli_spec.rb
@@ -183,9 +183,25 @@ describe "mixlib-install executable", :type => :aruba do
       end
     end
 
+    context "with future platform version" do
+      let(:platform) { "windows" }
+      let(:platform_version) { "2016" }
+      let(:additional_args) { "--attributes" }
+
+      let(:latest_version) { Mixlib::Install.available_versions("chefdk", "stable").last }
+      let(:filename) { "chefdk-#{latest_version}-x86.msi" }
+
+      it "has the correct artifact" do
+        require "digest"
+        sha256 = Digest::SHA256.hexdigest("./tmp/aruba/#{filename}")
+        expect(last_command_started).to have_output /sha256/
+      end
+    end
+
     context "with invalid platform version and architecture" do
       let(:platform_version) { "99.99" }
       let(:architecture) { "x86_64" }
+      let(:additional_args) { "--no-platform-version-compat" }
 
       it "returns no results" do
         expect(last_command_started).to have_output /No results found./

--- a/spec/unit/mixlib/install/backend/package_router_spec.rb
+++ b/spec/unit/mixlib/install/backend/package_router_spec.rb
@@ -232,6 +232,52 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
     end
   end
 
+  context "for a version of windows that is not added to our matrix" do
+    let(:channel) { :stable }
+    let(:product_name) { "chefdk" }
+    let(:product_version) { :latest }
+    let(:platform) { "windows" }
+    let(:platform_version) { "2016" }
+    let(:architecture) { "x86_64" }
+
+    it "can not find an artifact" do
+      expect(artifact_info).to be_empty
+    end
+
+    context "when product_version compat mode is set" do
+      let(:pv_compat) { true }
+
+      it "finds an artifact" do
+        expect(artifact_info).to be_a Mixlib::Install::ArtifactInfo
+        expect(artifact_info.platform).to eq "windows"
+        expect(artifact_info.platform_version).to eq "2012r2"
+        expect(artifact_info.architecture).to eq "x86_64"
+      end
+
+      context "when a desktop version is set" do
+        let(:platform_version) { "10" }
+
+        it "finds an artifact" do
+          expect(artifact_info).to be_a Mixlib::Install::ArtifactInfo
+          expect(artifact_info.platform).to eq "windows"
+          expect(artifact_info.platform_version).to eq "2012r2"
+          expect(artifact_info.architecture).to eq "x86_64"
+        end
+      end
+
+      context "when version ends with r2" do
+        let(:platform_version) { "2012r2" }
+
+        it "finds an artifact" do
+          expect(artifact_info).to be_a Mixlib::Install::ArtifactInfo
+          expect(artifact_info.platform).to eq "windows"
+          expect(artifact_info.platform_version).to eq "2012r2"
+          expect(artifact_info.architecture).to eq "x86_64"
+        end
+      end
+    end
+  end
+
   context "for automate" do
     let(:channel) { :stable }
     let(:product_name) { "automate" }


### PR DESCRIPTION
Fixes #169 

Windows artifacts now work properly when platform version compat is enabled. The option is enabled by default for the CLI. There is a backlog item to research how enabling this option by default will affect mixlib-install's API. For now, it seems to be OK with the CLI utility.

Added specs and tested windows versions: 2007 (not valid, but should still work with the code), 2008, 2008r2, 2012, 2012r2, 2016, 2016r2 (doesn't exist, but get the idea)

@schisamo @sersut 