### PR TITLE
Passing ChefClientFeature in ADDLOCAL parameter

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
@@ -107,10 +107,10 @@ set-alias install -value Install-Project
 
 Function Install-ChefMsi($msi, $addlocal) {
   if ($addlocal -eq "service") {
-    $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi ADDLOCAL=`"ChefServiceFeature`"" -Passthru -Wait
+    $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi ADDLOCAL=`"ChefClientFeature,ChefServiceFeature`"" -Passthru -Wait
   }
   ElseIf ($addlocal -eq "task") {
-    $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi ADDLOCAL=`"ChefSchTaskFeature`"" -Passthru -Wait
+    $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi ADDLOCAL=`"ChefClientFeature,ChefSchTaskFeature`"" -Passthru -Wait
   }
   ElseIf ($addlocal -eq "auto") {
     $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi" -Passthru -Wait


### PR DESCRIPTION
It's necessary to pass `ADDLOCAL=ChefClientFeature` for complete installation of `chef-client` along with `ChefServiceFeature` and `ChefSchTaskFeature` , otherwise several binaries don't get installed inside `C:/opscode/chef/embedded/bin` folder.