### PR TITLE
COOL-629 Honor -download_directory flag in ScriptGenerator

### DIFF
--- a/lib/mixlib/install/script_generator.rb
+++ b/lib/mixlib/install/script_generator.rb
@@ -130,9 +130,12 @@ module Mixlib
       # @return [String] shell variable lines
       # @api private
       def install_command_vars_for_powershell
+        d_flag = install_flags.nil? ? nil : install_flags.match(/-download_directory (\S+)/)
+        download_directory = d_flag.nil? ? "$env:TEMP" : d_flag[1]
         [
           shell_var("chef_omnibus_root", root),
-          shell_var("msi", "$env:TEMP\\chef-#{version}.msi"),
+          shell_var("msi", "#{download_directory}\\chef-#{version}.msi"),
+          shell_var("download_directory", download_directory),
         ].tap do |vars|
           if install_msi_url
             vars << shell_var("chef_msi_url", install_msi_url)

--- a/spec/unit/mixlib/install/script_generator_spec.rb
+++ b/spec/unit/mixlib/install/script_generator_spec.rb
@@ -106,6 +106,21 @@ describe Mixlib::Install::ScriptGenerator do
         expect(installer.install_command).to match(%r{\$chef_metadata_url = "#{Regexp.escape(target_url)}"})
       end
 
+      it "sets the default download_directory" do
+        expect(installer.install_command).to match(%r{\$download_directory = "\$env:TEMP"})
+      end
+
+      describe "customizing -download_directory through install_flags" do
+        let(:download_directory) { "C:\\bubulubu" }
+        let(:install_flags) { "-download_directory #{download_directory}" }
+
+        before { installer.install_flags = install_flags }
+
+        it "sets the custom download_directory variable" do
+          expect(installer.install_command).to match(%r{\$download_directory = "#{Regexp.escape(download_directory)}"})
+        end
+      end
+
       describe "for a nightly" do
         let(:installer) { described_class.new("1.2.1", true, omnibus_url: "http://f/install.sh", nightlies: true) }
         let(:target_url) { "http://f/metadata?p=windows&m=x86_64&pv=2008r2&v=1.2.1&nightlies=true" }


### PR DESCRIPTION
Now we can actually use the `-download_directory` flag for Windows
systems because before we were unable to do this.

If the flag is not provided we will default to `$env:TEMP`

We no longer delete the downloaded package so we can leverage it on next
installs.

Closes https://github.com/chef/mixlib-install/issues/174

Signed-off-by: Salim Afiune <afiune@chef.io>