### PR TITLE
Force ASCII encoding for variables.

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
@@ -1,3 +1,5 @@
+[Console]::OutputEncoding = New-Object -typename System.Text.ASCIIEncoding
+
 function Get-PlatformVersion {
   switch -regex ((Get-WMIQuery win32_operatingsystem).version) {
     '10\.0\.\d+' {$platform_version = '2016'}


### PR DESCRIPTION
In some situations the strings for various variables are UTF-8 encoded. This causes issues when ruby reads the variables and the strings contain UTF-8 escape sequences and is unable to match strings as needed.

/cc @chef/engineering-services 