### PR TITLE
dynamically resolve platform version compat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ artifact.platform # => "ubuntu"
 artifact.platform_version # => "14.04"
 ```
 
+`platform_version_compatibility_mode` will automatically be enabled if platform options are not specified.
+
 ### List the available versions for a product and channel
 #### Instance method
 ```ruby

--- a/spec/unit/mixlib/install/options_spec.rb
+++ b/spec/unit/mixlib/install/options_spec.rb
@@ -29,6 +29,36 @@ context "Mixlib::Install::Options" do
   let(:shell_type) { nil }
   let(:user_agent_headers) { nil }
 
+  context "for platform_version_compatibility_mode option" do
+    let(:product_name) { "chef" }
+    let(:channel) { :stable }
+
+    context "when not setting platform info" do
+      it "is set to true" do
+        mi = Mixlib::Install.new(product_name: product_name, channel: channel)
+        expect(mi.options.platform_version_compatibility_mode).to be true
+      end
+    end
+
+    context "when setting platform info" do
+      let(:platform) { "ubuntu" }
+      let(:platform_version) { "13.04" }
+      let(:architecture) { "x86_64" }
+
+      it "is set to false" do
+        mi = Mixlib::Install.new(product_name: product_name, channel: channel, platform: platform, platform_version: platform_version, architecture: architecture)
+        expect(mi.options.platform_version_compatibility_mode).to be false
+      end
+
+      context "when setting platform_version_compatibility_mode true" do
+        it "is set to true" do
+          mi = Mixlib::Install.new(product_name: product_name, channel: channel, platform: platform, platform_version: platform_version, architecture: architecture, platform_version_compatibility_mode: true)
+          expect(mi.options.platform_version_compatibility_mode).to be true
+        end
+      end
+    end
+  end
+
   context "for invalid architecture option" do
     let(:architecture) { "foo" }
 


### PR DESCRIPTION
This PR piggy backs off of platform-options-fix.

There are 3 use cases to consider:
1 - Implementations where platform options and are not configured, and compat mode is defaulted.
2 - Implementations where platform options are set, but compat mode is defaulted.
3 - Implementations where compat mode is set to true.
Use Cases 2 and 3 will be unaffected by this change.
Use Case 1 will be affected in that where results used to return an empty array may now return compatible artifacts, which I would argue is desired behavior. However, this is a change to the existing API.

Signed-off-by: Patrick Wright <patrick@chef.io>