### PR TITLE
Raise exception when there are no results

### DIFF
--- a/lib/mixlib/install/cli.rb
+++ b/lib/mixlib/install/cli.rb
@@ -66,10 +66,10 @@ If no earlier version is found the earliest version available will be set.",
           mixlib_install_options.merge!(Mixlib::Install.detect_platform)
         end
 
-        say "Querying for artifact with options:\n#{JSON.pretty_generate(mixlib_install_options)}"
-        artifact = Mixlib::Install.new(mixlib_install_options).artifact_info
-        if artifact.nil? || artifact.is_a?(Array)
-          abort "No results found."
+        begin
+          artifact = Mixlib::Install.new(mixlib_install_options).artifact_info
+        rescue Mixlib::Install::Backend::ArtifactsNotFound => e
+          abort e.message
         end
 
         if options[:url]

--- a/spec/fixtures/vcr/Mixlib_Install_Backend_PackageRouter_all_channels/for_a_product_that_does_not_exist_in_a_specific_channel/raises_an_exception.yml
+++ b/spec/fixtures/vcr/Mixlib_Install_Backend_PackageRouter_all_channels/for_a_product_that_does_not_exist_in_a_specific_channel/raises_an_exception.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://packages.chef.io/api/v1/unstable/chef-ha/versions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      - mixlib-install/2.1.12
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Artifactory-Id:
+      - 91ce5e713616ab7d:4a171d30:159f1ef5b3a:-7f1a
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Fastly-Debug-Digest:
+      - 19c9baa4a97064c0b9255dfc282802a0cc1e2c1eb3b5fb159a03a8a44c15559d
+      Content-Length:
+      - '87'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 08 Mar 2017 21:34:35 GMT
+      Age:
+      - '1132'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sjc3123-SJC, cache-den6022-DEN
+      X-Cache:
+      - HIT, HIT
+      X-Cache-Hits:
+      - 1, 1
+      X-Timer:
+      - S1489008875.376129,VS0,VE1
+    body:
+      encoding: UTF-8
+      string: |2
+
+        {
+        "results" : [  ],
+        "range" : {
+          "start_pos" : 0,
+          "end_pos" : 0,
+          "total" : 0
+        }
+        }
+    http_version: 
+  recorded_at: Wed, 08 Mar 2017 21:34:35 GMT
+recorded_with: VCR 3.0.3

--- a/spec/functional/mixlib/install/cli_spec.rb
+++ b/spec/functional/mixlib/install/cli_spec.rb
@@ -205,7 +205,7 @@ describe "mixlib-install executable", :type => :aruba do
       let(:additional_args) { "--no-platform-version-compat" }
 
       it "returns no results" do
-        expect(last_command_started).to have_output /No results found./
+        expect(last_command_started).to have_output /No artifacts found matching criteria./
       end
     end
 

--- a/spec/unit/mixlib/install/backend/package_router_spec.rb
+++ b/spec/unit/mixlib/install/backend/package_router_spec.rb
@@ -137,6 +137,15 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
     end
   end
 
+  context "for a product that does not exist in a specific channel" do
+    let(:channel) { :unstable }
+    let(:product_name) { "ha" }
+
+    it "raises an exception" do
+      expect { artifact_info }.to raise_error Mixlib::Install::Backend::ArtifactsNotFound
+    end
+  end
+
   context "for a product without native 64-bit builds" do
     let(:channel) { :stable }
     let(:product_name) { "chefdk" }
@@ -191,7 +200,7 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
     let(:architecture) { "x86_64" }
 
     it "can not find an artifact" do
-      expect(artifact_info).to be_empty
+      expect { artifact_info }.to raise_error Mixlib::Install::Backend::ArtifactsNotFound
     end
 
     context "when product_version compat mode is set" do
@@ -215,7 +224,7 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
     let(:architecture) { "x86_64" }
 
     it "can not find an artifact" do
-      expect(artifact_info).to be_empty
+      expect { artifact_info }.to raise_error Mixlib::Install::Backend::ArtifactsNotFound
     end
 
     context "when product_version compat mode is set" do
@@ -239,7 +248,7 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
     let(:architecture) { "x86_64" }
 
     it "can not find an artifact" do
-      expect(artifact_info).to be_empty
+      expect { artifact_info }.to raise_error Mixlib::Install::Backend::ArtifactsNotFound
     end
 
     context "when product_version compat mode is set" do


### PR DESCRIPTION
This has been a long awaited changed which will be included in the next major bump release.

Instead of returning an empty Array when there are no results, mixlib-install will now raise an AritfactsNotFound exception. The exceptions will also provide more insight into the options that were passed.

Please review the other commits to understand why I removed/replaced other exceptions that were being (read attempted to be) raised.

@chef/engineering-services 


