### PR TITLE
Filter appx packages in search results

### DIFF
--- a/lib/mixlib/install/backend/base.rb
+++ b/lib/mixlib/install/backend/base.rb
@@ -27,7 +27,7 @@ module Mixlib
         attr_reader :options
 
         SUPPORTED_WINDOWS_DESKTOP_VERSIONS = %w{7 8 8.1 10}
-        SUPPORTED_APPX_PLATFORM_VERSIONS = %w{2016}
+        SUPPORTED_APPX_PLATFORM_VERSIONS = %w{8 8.1 10 2016}
 
         def initialize(options)
           @options = options

--- a/lib/mixlib/install/backend/base.rb
+++ b/lib/mixlib/install/backend/base.rb
@@ -27,7 +27,6 @@ module Mixlib
         attr_reader :options
 
         SUPPORTED_WINDOWS_DESKTOP_VERSIONS = %w{7 8 8.1 10}
-        SUPPORTED_APPX_PLATFORM_VERSIONS = %w{8 8.1 10 2016}
 
         def initialize(options)
           @options = options
@@ -193,14 +192,12 @@ EOF
           # add the remaining cloned artifacts to the original set
           artifacts += new_artifacts
 
-          # remove any appx packages that are mapped to a non-supported platform
-          artifacts.each do |r|
-            next unless r.platform == "windows"
-
-            if /\.appx/ =~ r.url
-              artifacts.delete(r) unless SUPPORTED_APPX_PLATFORM_VERSIONS.include?(r.platform_version)
-            end
+          # TODO: this explicitly removes all appx results and should be
+          # modified to enable on the appropriate platforms
+          artifacts.delete_if do |x|
+            /\.appx/ =~ x.url
           end
+
           artifacts
         end
 

--- a/lib/mixlib/install/backend/base.rb
+++ b/lib/mixlib/install/backend/base.rb
@@ -27,6 +27,7 @@ module Mixlib
         attr_reader :options
 
         SUPPORTED_WINDOWS_DESKTOP_VERSIONS = %w{7 8 8.1 10}
+        SUPPORTED_APPX_PLATFORM_VERSIONS = %w{2016}
 
         def initialize(options)
           @options = options
@@ -191,6 +192,16 @@ EOF
 
           # add the remaining cloned artifacts to the original set
           artifacts += new_artifacts
+
+          # remove any appx packages that are mapped to a non-supported platform
+          artifacts.each do |r|
+            next unless r.platform == "windows"
+
+            if /\.appx/ =~ r.url
+              artifacts.delete(r) unless SUPPORTED_APPX_PLATFORM_VERSIONS.include?(r.platform_version)
+            end
+          end
+          artifacts
         end
 
         #

--- a/spec/functional/mixlib/install/cli_spec.rb
+++ b/spec/functional/mixlib/install/cli_spec.rb
@@ -198,21 +198,6 @@ describe "mixlib-install executable", :type => :aruba do
       end
     end
 
-    context "with future platform appx package" do
-      let(:platform) { "windows" }
-      let(:platform_version) { "2016" }
-      let(:additional_args) { "--attributes" }
-
-      let(:latest_version) { Mixlib::Install.available_versions("chef", "stable").last }
-      let(:filename) { "chef-#{latest_version}-x86.appx" }
-
-      it "has the correct artifact" do
-        require "digest"
-        sha256 = Digest::SHA256.hexdigest("./tmp/aruba/#{filename}")
-        expect(last_command_started).to have_output /sha256/
-      end
-    end
-
     context "with invalid platform version and architecture" do
       let(:platform) { "foo" }
       let(:platform_version) { "99.99" }

--- a/spec/functional/mixlib/install/cli_spec.rb
+++ b/spec/functional/mixlib/install/cli_spec.rb
@@ -198,6 +198,21 @@ describe "mixlib-install executable", :type => :aruba do
       end
     end
 
+    context "with future platform appx package" do
+      let(:platform) { "windows" }
+      let(:platform_version) { "2016" }
+      let(:additional_args) { "--attributes" }
+
+      let(:latest_version) { Mixlib::Install.available_versions("chef", "stable").last }
+      let(:filename) { "chef-#{latest_version}-x86.appx" }
+
+      it "has the correct artifact" do
+        require "digest"
+        sha256 = Digest::SHA256.hexdigest("./tmp/aruba/#{filename}")
+        expect(last_command_started).to have_output /sha256/
+      end
+    end
+
     context "with invalid platform version and architecture" do
       let(:platform) { "foo" }
       let(:platform_version) { "99.99" }


### PR DESCRIPTION
Remove appx packages from search results on platforms that do not support appx packages

This is to get around a bug wherein mixlib-install is returning appx packages on 2008r2 (which doesn't support appx). This is not intended to resolve https://github.com/chef/mixlib-install/issues/189

Also I'm pretty sure the added test doesn't... actually do anything. I couldn't make it fail even when changing the expectations :\

Signed-off-by: Scott Hain <shain@chef.io>

@chef/engineering-services 