### PR TITLE
Install script option overrides

### DIFF
--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -197,6 +197,8 @@ module Mixlib
     # ------------------
     # base_url [String]
     #   url pointing to the omnitruck to be queried by the script.
+    # http_proxy [String]
+    #   http proxy url
     #
     def self.install_ps1(context = {})
       Mixlib::Install::Generator::PowerShell.install_ps1(context)

--- a/lib/mixlib/install/generator/base.rb
+++ b/lib/mixlib/install/generator/base.rb
@@ -49,6 +49,7 @@ module Mixlib
             # Default values to use incase they are not set in the context
             context[:base_url] ||= "https://omnitruck.chef.io"
             context[:user_agent_string] = Util.user_agent_string(context[:user_agent_headers])
+            context[:http_proxy] ||= nil
 
             context_object = OpenStruct.new(context).instance_eval { binding }
             ERB.new(File.read("#{script_path}.erb")).result(context_object)

--- a/lib/mixlib/install/generator/bourne.rb
+++ b/lib/mixlib/install/generator/bourne.rb
@@ -57,7 +57,13 @@ module Mixlib
 project=#{options.product_name}
 version=#{options.product_version}
 channel=#{options.channel}
+#{install_command_vars}
 EOS
+        end
+
+        def install_command_vars
+          return if options.install_command_options.nil?
+          options.install_command_options.map { |key, value| "#{key}='#{value}'" }.join("\n")
         end
       end
     end

--- a/lib/mixlib/install/generator/powershell.rb
+++ b/lib/mixlib/install/generator/powershell.rb
@@ -25,7 +25,7 @@ module Mixlib
           install_project_module = []
           install_project_module << get_script("helpers.ps1", context)
           install_project_module << get_script("get_project_metadata.ps1", context)
-          install_project_module << get_script("install_project.ps1")
+          install_project_module << get_script("install_project.ps1", context)
 
           install_command = []
           install_command << ps1_modularize(install_project_module.join("\n"), "Omnitruck")
@@ -71,7 +71,12 @@ module Mixlib
           cmd << " -version #{options.product_version}"
           cmd << " -channel #{options.channel}"
           cmd << " -architecture #{options.architecture}" if options.architecture
+          cmd << install_command_params if options.install_command_options
           cmd << "\n"
+        end
+
+        def install_command_params
+          options.install_command_options.map { |key, value| " -#{key} '#{value}'" }.join
         end
       end
     end

--- a/lib/mixlib/install/generator/powershell/scripts/install_project.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/install_project.ps1.erb
@@ -45,8 +45,13 @@ function Install-Project {
     $architecture = 'auto',
     [validateset('auto', 'service', 'task')]
     [string]
-    $daemon = 'auto'
+    $daemon = 'auto',
+    [string]
+    $http_proxy<% unless http_proxy.nil? %> = '<%= http_proxy %>'<% end %>
   )
+
+  # Set http_proxy as env var
+  $env:http_proxy = $http_proxy
 
   $package_metadata = Get-ProjectMetadata -project $project -channel $channel -version $version -prerelease:$prerelease -nightlies:$nightlies -architecture $architecture
 

--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -60,6 +60,7 @@ module Mixlib
         :platform_version_compatibility_mode,
         :include_metadata,
         :user_agent_headers,
+        :install_command_options,
       ]
 
       SUPPORTED_WINDOWS_DESKTOP_VERSIONS = %w{7 8 8.1 10}

--- a/spec/unit/mixlib/install/generator_spec.rb
+++ b/spec/unit/mixlib/install/generator_spec.rb
@@ -166,4 +166,45 @@ context "Mixlib::Install::Generator", :vcr do
       end
     end
   end
+
+  context "when setting install_command_options" do
+    let(:channel) { :stable }
+
+    context "for powershell install params" do
+      let(:install_command_options) do
+        { http_proxy: "http://sam:iam@greeneggsandham:1111" }
+      end
+
+      let(:add_options) do
+        {
+          install_command_options: install_command_options,
+          shell_type: :ps1,
+        }
+      end
+
+      it "#install_command adds http_proxy param" do
+        expect(install_script).to match(/install -project .* -version .* -channel .* -http_proxy '#{install_command_options[:http_proxy]}'\n/)
+      end
+
+      it "#install_ps1 adds http_proxy param" do
+        expect(Mixlib::Install.install_ps1(install_command_options)).to match(/\$http_proxy = '#{install_command_options[:http_proxy]}'/)
+      end
+    end
+
+    context "for bourne install params" do
+      let(:install_command_options) do
+        { cmdline_dl_dir: "/hereiam" }
+      end
+
+      let(:add_options) do
+        {
+          install_command_options: install_command_options,
+        }
+      end
+
+      it "adds cmdline_dl_dir var" do
+        expect(install_script).to match(/cmdline_dl_dir='#{install_command_options[:cmdline_dl_dir]}'/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The new `install_command_options` option takes a Hash of key/value pairs.

`#install_command`:
- for ps1 this will convert the options into command lines params for the generated install command
- for sh this will convert the options to the generated set of variables

`#install_ps1` and `#install_sh`:
This will take the options and set the `context` Hash which is passed as erb templates attributes.

This feature was added to maintain parity with test-kitchen which supports the provisioner setting `http_proxy`.  However, now we can support overriding any sh variable or ps1 install param.

@chef/engineering-services
