### PR TITLE
remove http_proxy from context

### DIFF
--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -197,8 +197,6 @@ module Mixlib
     # ------------------
     # base_url [String]
     #   url pointing to the omnitruck to be queried by the script.
-    # http_proxy [String]
-    #   http proxy url
     #
     def self.install_ps1(context = {})
       Mixlib::Install::Generator::PowerShell.install_ps1(context)

--- a/lib/mixlib/install/generator/base.rb
+++ b/lib/mixlib/install/generator/base.rb
@@ -49,7 +49,6 @@ module Mixlib
             # Default values to use incase they are not set in the context
             context[:base_url] ||= "https://omnitruck.chef.io"
             context[:user_agent_string] = Util.user_agent_string(context[:user_agent_headers])
-            context[:http_proxy] ||= nil
 
             context_object = OpenStruct.new(context).instance_eval { binding }
             ERB.new(File.read("#{script_path}.erb")).result(context_object)

--- a/lib/mixlib/install/generator/powershell.rb
+++ b/lib/mixlib/install/generator/powershell.rb
@@ -25,7 +25,7 @@ module Mixlib
           install_project_module = []
           install_project_module << get_script("helpers.ps1", context)
           install_project_module << get_script("get_project_metadata.ps1", context)
-          install_project_module << get_script("install_project.ps1", context)
+          install_project_module << get_script("install_project.ps1")
 
           install_command = []
           install_command << ps1_modularize(install_project_module.join("\n"), "Omnitruck")

--- a/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
@@ -47,7 +47,7 @@ function Install-Project {
     [string]
     $daemon = 'auto',
     [string]
-    $http_proxy<% unless http_proxy.nil? %> = '<%= http_proxy %>'<% end %>
+    $http_proxy
   )
 
   # Set http_proxy as env var

--- a/spec/unit/mixlib/install/generator_spec.rb
+++ b/spec/unit/mixlib/install/generator_spec.rb
@@ -185,10 +185,6 @@ context "Mixlib::Install::Generator", :vcr do
       it "#install_command adds http_proxy param" do
         expect(install_script).to match(/install -project .* -version .* -channel .* -http_proxy '#{install_command_options[:http_proxy]}'\n/)
       end
-
-      it "#install_ps1 adds http_proxy param" do
-        expect(Mixlib::Install.install_ps1(install_command_options)).to match(/\$http_proxy = '#{install_command_options[:http_proxy]}'/)
-      end
     end
 
     context "for bourne install params" do


### PR DESCRIPTION
Signed-off-by: Patrick Wright <patrick@chef.io>

I got ahead of myself with this change. `http_proxy` does not need to be templated for the class method to return the raw install.ps1 script.