### PR TITLE
Add sparc mapping methods for architecture input parameter

### DIFF
--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -76,6 +76,8 @@ module Mixlib
 
         resolve_platform_version_compatibility_mode!
 
+        map_solaris_architectures!
+
         map_windows_versions!
 
         validate!
@@ -223,6 +225,10 @@ Must be one of: #{SUPPORTED_SHELL_TYPES.join(", ")}
 Must provide platform, platform version and architecture when specifying any platform details
           EOS
         end
+      end
+
+      def map_solaris_architecture!
+        options[:architecture] = Util.map_solaris_architecture(architecture)
       end
 
       def map_windows_versions!

--- a/lib/mixlib/install/util.rb
+++ b/lib/mixlib/install/util.rb
@@ -130,6 +130,16 @@ module Mixlib
           user_agents.flatten.compact.uniq.join(" ")
         end
 
+        def map_solaris_architecture(architecture)
+          # Map sun4u and sun4v to sparc
+          case architecture
+          when "sun4u", "sun4v"
+            "sparc"
+          else
+            architecture
+          end
+        end
+
         def map_windows_version(version)
           # This logic does not try to compare and determine proper versions based on conditions or ranges.
           # These are here to improve UX for desktop versions.


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

I believe this will fix the situation where you pass something like this:
```
    chef_ingredient("chef") do
      architecture "sun4v"
      platform_version_compatibility_mode true
    end
```

(sun4v, sun4u, and sparc are all valid inputs for the architecture param)

@chef/engineering-services 