### PR TITLE
Return versions sorted by mixlib-versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [3.3.0]
+- `available_versions` now returns a sorted list of versions (per mixlib-versioning)
+
 ## [3.2.2]
 - Fix issue [#206](https://github.com/chef/mixlib-install/issues/206) - Missing metadata now returns `nil`
 

--- a/lib/mixlib/install/backend/package_router.rb
+++ b/lib/mixlib/install/backend/package_router.rb
@@ -54,8 +54,8 @@ module Mixlib
           # We are only including a single property, version and that exists
           # under the properties in the following structure:
           # "properties" => [ {"key"=>"omnibus.version", "value"=>"12.13.3"} ]
-          ver_list = versions.map { |i| extract_version_from_response(i) }
-          ver_list.uniq
+          ver_list = versions.map { |i| Mixlib::Versioning.parse(extract_version_from_response(i)) }.sort
+          ver_list.uniq.map(&:to_s)
         end
 
         #

--- a/lib/mixlib/install/version.rb
+++ b/lib/mixlib/install/version.rb
@@ -1,5 +1,5 @@
 module Mixlib
   class Install
-    VERSION = "3.2.2"
+    VERSION = "3.3.0"
   end
 end

--- a/spec/unit/mixlib/install/backend/package_router_spec.rb
+++ b/spec/unit/mixlib/install/backend/package_router_spec.rb
@@ -50,6 +50,23 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
   let(:package_router) { Mixlib::Install::Backend::PackageRouter.new(mixlib_options) }
   let(:artifact_info) { package_router.info }
 
+  context "for chef/stable" do
+    let(:channel) { :stable }
+    let(:product_name) { "chef" }
+
+    # 12.20.3 was released chronologically after 13.0.118. We want to make sure
+    # it appears BEFORE 13.0.118 in the list of available versions to prove that
+    # versions are sorted by semver rather than by release date.
+    context "when there is a release of a previous major/minor version" do
+      let(:idx_12_20_3) { package_router.available_versions.index("12.20.3") }
+      let(:idx_13_0_118) { package_router.available_versions.index("13.0.118") }
+
+      it "returns properly sorted list of available_versions" do
+        expect(idx_12_20_3).to be < idx_13_0_118
+      end
+    end
+  end
+
   context "for chef/stable with specific version" do
     let(:channel) { :stable }
     let(:product_name) { "chef" }


### PR DESCRIPTION
available_versions now returns a list sorted by semver rather than release date

Old Response:
```ruby
irb(main):002:0> Mixlib::Install.available_versions('chef', 'stable')
=> ["12.0.3", "12.1.2", "12.2.0-rc.1", "12.2.1", "12.3.0-rc.0", "12.3.0", "10.12.0", "10.14.0", "10.14.2", "10.14.4", "10.16.0", "10.16.2", "10.16.4", "10.16.6", "10.18.0", "10.18.2", "10.20.0", "10.22.0", "10.24.0", "10.24.2", "10.24.4", "10.26.0", "10.28.0", "10.28.2", "10.30.2", "10.30.4", "10.32.2", "10.34.0", "10.34.2", "10.34.4", "11.0.0", "11.2.0", "11.4.0", "11.4.2", "11.4.4", "11.10.0", "11.10.2", "11.10.4", "11.12.0", "11.12.2", "11.12.4", "11.12.8", "11.14.2", "11.14.6", "11.16.0", "11.16.2", "11.16.4", "11.6.0", "11.6.2", "11.8.0", "11.8.2", "10.34.6", "11.18.0", "11.18.10", "11.18.12", "11.18.6", "12.0.0", "12.0.1", "12.1.0", "12.1.1", "12.4.0", "12.4.1", "12.4.2", "12.4.3", "12.5.1", "12.6.0", "12.7.2", "12.8.1", "12.9.38", "12.9.41", "12.10.24", "12.11.18", "12.12.13", "12.12.15", "12.13.30", "12.13.37", "12.14.60", "12.14.77", "12.14.89", "12.15.19", "12.16.42", "12.17.44", "12.18.31", "12.19.33", "12.19.36", "13.0.113", "13.0.118", "12.20.3", "13.1.31"]
```

New Response:
```ruby
irb(main):002:0> Mixlib::Install.available_versions('chef', 'stable')
=> ["10.12.0", "10.14.0", "10.14.2", "10.14.4", "10.16.0", "10.16.2", "10.16.4", "10.16.6", "10.18.0", "10.18.2", "10.20.0", "10.22.0", "10.24.0", "10.24.2", "10.24.4", "10.26.0", "10.28.0", "10.28.2", "10.30.2", "10.30.4", "10.32.2", "10.34.0", "10.34.2", "10.34.4", "10.34.6", "11.0.0", "11.2.0", "11.4.0", "11.4.2", "11.4.4", "11.6.0", "11.6.2", "11.8.0", "11.8.2", "11.10.0", "11.10.2", "11.10.4", "11.12.0", "11.12.2", "11.12.4", "11.12.8", "11.14.2", "11.14.6", "11.16.0", "11.16.2", "11.16.4", "11.18.0", "11.18.6", "11.18.10", "11.18.12", "12.0.0", "12.0.1", "12.0.3", "12.1.0", "12.1.1", "12.1.2", "12.2.0-rc.1", "12.2.1", "12.3.0-rc.0", "12.3.0", "12.4.0", "12.4.1", "12.4.2", "12.4.3", "12.5.1", "12.6.0", "12.7.2", "12.8.1", "12.9.38", "12.9.41", "12.10.24", "12.11.18", "12.12.13", "12.12.15", "12.13.30", "12.13.37", "12.14.60", "12.14.77", "12.14.89", "12.15.19", "12.16.42", "12.17.44", "12.18.31", "12.19.33", "12.19.36", "12.20.3", "13.0.113", "13.0.118", "13.1.31"]
```
Signed-off-by: Tom Duffield <tom@chef.io>