### PR TITLE
Allow mapped architectures (for example i686 or amd64) as valid input…

### DIFF
--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -167,7 +167,7 @@ module Mixlib
       end
 
       def validate_architecture
-        unless architecture.nil? || SUPPORTED_ARCHITECTURES.include?(architecture)
+        unless architecture.nil? || SUPPORTED_ARCHITECTURES.include?(Util.normalize_architecture(architecture))
           errors << <<-EOS
 Unknown architecture #{architecture}.
 Must be one of: #{SUPPORTED_ARCHITECTURES.join(", ")}

--- a/spec/functional/mixlib/install/cli_spec.rb
+++ b/spec/functional/mixlib/install/cli_spec.rb
@@ -183,6 +183,22 @@ describe "mixlib-install executable", :type => :aruba do
       end
     end
 
+    context "with valid platform version and architecture that is mapped" do
+      let(:platform) { "ubuntu" }
+      let(:platform_version) { "14.04" }
+      let(:architecture) { "i686" }
+      let(:additional_args) { "--attributes" }
+
+      let(:latest_version) { Mixlib::Install.available_versions("chef", "stable").last }
+      let(:filename) { "chef_#{latest_version}-1_i386.deb" }
+
+      it "has the correct artifact" do
+        require "digest"
+        sha256 = Digest::SHA256.hexdigest("./tmp/aruba/#{filename}")
+        expect(last_command_started).to have_output /sha256/
+      end
+    end
+
     context "with future platform version" do
       let(:platform) { "windows" }
       let(:platform_version) { "2016" }


### PR DESCRIPTION
…, since they will then be mapped to the correct backend arch

Signed-off-by: Scott Hain <shain@chef.io>

@chef/engineering-services 