### PR TITLE
Silence the install warning on CI systems.

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/install_package.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/install_package.sh
@@ -8,7 +8,7 @@
 # $version: The version requested. Used only for warning user if not set.
 ############
 
-if test "x$version" = "x"; then
+if test "x$version" = "x" -a "x$CI" != "xtrue"; then
   echo
   echo "WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING"
   echo


### PR DESCRIPTION
Given that CI is one of the mentioned exceptions, it would be nice if my build logs didn't have scary things.

I think that syntax should be of the ancients but I defer to a higher authority.

Copying over from https://github.com/chef/omnitruck/pull/110 since that side is dead-ish.