### PR TITLE
Update platform detection shellout on windows

### DIFF
--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -151,7 +151,11 @@ module Mixlib
                      f.puts detect_platform_ps1
                    end
 
-                   Mixlib::ShellOut.new("powershell.exe -file #{File.join(d, "detect_platform.ps1")}").run_command
+                   # An update to most Windows versions > 2008r2 now sets the execution policy
+                   # to disallow unsigned powershell scripts. This changes it for just this
+                   # powershell session, which allows this to run even if the execution policy
+                   # is set higher.
+                   Mixlib::ShellOut.new("powershell.exe -file #{File.join(d, "detect_platform.ps1")}", :env => { "PSExecutionPolicyPreference" => "Bypass" }).run_command
                  end
                else
                  Mixlib::ShellOut.new(detect_platform_sh).run_command


### PR DESCRIPTION
...to allow execution of unsigned platform detect script

Signed-off-by: Scott Hain <shain@chef.io>

@chef/engineering-services 

looks like this was just updated in a recent windows update!
https://msdn.microsoft.com/powershell/reference/5.1/Microsoft.PowerShell.Core/about/about_Execution_Policies

Verified on 2008r2+