### PR TITLE
Only override http proxy if a value is supplied. 

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
+++ b/lib/mixlib/install/generator/powershell/scripts/install_project.ps1
@@ -58,8 +58,10 @@ function Install-Project {
   )
 
   # Set http_proxy as env var
-  $env:http_proxy = $http_proxy
-
+  if(-not [string]::IsNullOrEmpty($http_proxy)) {
+    $env:http_proxy = $http_proxy
+  }
+  
   if (-not [string]::IsNullOrEmpty($download_url_override)) {
     $download_url = $download_url_override
     $sha256 = $checksum


### PR DESCRIPTION
The chef-client-updater cookbook doesn't work behind a proxy as the `http_proxy` environment variable is overwritten by the Powershell install script being passed a null value.

This simple change just adds a guard condition so that only if a value is passed to the script is it used.

This is related to #201 

This is an Obvious fix.