### PR TITLE
Use reject, rather than delete_if, for products_available_on_downloads_site

### DIFF
--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -178,7 +178,7 @@ module Mixlib
       #   :key => product_key
       #   :value => Mixlib::Install::Product instance
       def products_available_on_downloads_site
-        @product_map.delete_if do |product_key, product|
+        @product_map.reject do |product_key, product|
           product.downloads_product_page_url == :not_available
         end
       end


### PR DESCRIPTION
`delete_if` will modify the in-memory product_map, meaning that if you call `PRODUCT_MATRIX.products_available_on_downloads_site`, `PRODUCT_MATRIX` will only include products that are on the download site.

`#reject` will simply return a new array, which is technically what I think we want.

```ruby
▶ irb
irb(main):001:0> a = [1,2,3,4,5]
=> [1, 2, 3, 4, 5]
irb(main):002:0> a.reject { |i| i.even? }
=> [1, 3, 5]
irb(main):003:0> a
=> [1, 2, 3, 4, 5]
irb(main):004:0> a.delete_if { |i| i.even? }
=> [1, 3, 5]
irb(main):005:0> a
=> [1, 3, 5]
```

Signed-off-by: Tom Duffield <tom@chef.io>