### PR TITLE
Return nil when looking up non-existing products

### DIFF
--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -162,6 +162,9 @@ module Mixlib
       #
       # @return [Product]
       def lookup(key, version = :latest)
+        # return nil unless the product exists
+        return nil unless @product_map.key?(key)
+
         product = @product_map[key]
         # We set the lookup version for the product to a very high number in
         # order to mimic :latest so that one does not need to handle this

--- a/spec/unit/mixlib/install/product_spec.rb
+++ b/spec/unit/mixlib/install/product_spec.rb
@@ -167,6 +167,10 @@ context "PRODUCT_MATRIX" do
     end
   end
 
+  it "returns nil when looking up a non-existent product" do
+    expect(PRODUCT_MATRIX.lookup("no-such-project")).to be_nil
+  end
+
   it "returns nil for unset parameters" do
     expect(PRODUCT_MATRIX.lookup("chef").ctl_command).to be_nil
   end


### PR DESCRIPTION
When calling `PRODUCT_MATRIX.lookup` for a product that does not exist,
we'd try to call the `version` method on nil, resulting in an "undefined
method" error. Now we return nil to the caller early before trying to
manipulate it.

Signed-off-by: Adam Leff <adam@leff.co>