### PR TITLE
Update expeditor config to allow gem builds

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -2,10 +2,13 @@ slack:
   notify_channel: jex-notify
 
 github:
-  maintainer_group: chef/package-distribution-maintainers
+  maintainer_group: chef/jex-team
   version_tag_format: v{{version}}
   minor_bump_labels:
     - "Version: Bump Minor"
+
+rubygems:
+  - mixlib-install
 
 merge_actions:
   - built_in:bump_version:
@@ -18,3 +21,10 @@ merge_actions:
       ignore_labels:
         - "Changelog: Skip Update"
         - "Expeditor: Skip All"
+  - built_in:build_gem:
+      only_if:
+        - built_in:bump_version
+
+promote:
+  action:
+    - built_in:publish_rubygems


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

I changed the maintainer group since `chef/package-distribution-maintainers` doesn't exist. 

@chef/jex-team 