### PR TITLE
Adding TLS negotiation support for older versions of .NET

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
@@ -1,4 +1,5 @@
 [Console]::OutputEncoding = New-Object -typename System.Text.ASCIIEncoding
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
 
 function Get-PlatformVersion {
   switch -regex ((Get-Win32OS).version) {

--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
@@ -1,5 +1,5 @@
 [Console]::OutputEncoding = New-Object -typename System.Text.ASCIIEncoding
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12'
 
 function Get-PlatformVersion {
   switch -regex ((Get-Win32OS).version) {


### PR DESCRIPTION
This should allow older verisons of .NET that are on operating systems forced to negotiate TLS 1.2 to successfully download our software using mixlib-install.

Corrects https://github.com/chef/mixlib-install/issues/253