### PR TITLE
Move remap logic from install.sh to omnitruck

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -55,19 +55,6 @@ elif test -f "/etc/redhat-release"; then
     platform="el"
   fi
 
-elif test -f "/etc/system-release"; then
-  platform=`sed 's/^\(.\+\) release.\+/\1/' /etc/system-release | tr '[A-Z]' '[a-z]'`
-  platform_version=`sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/system-release | tr '[A-Z]' '[a-z]'`
-  # amazon is built off of centos, so act like RHEL
-  # Version 1. Example: Amazon Linux AMI release 2017.09
-  if test "$platform" = "amazon linux ami"; then
-    platform="el"
-    platform_version="6.0"
-  # Version 2. Example: Amazon Linux release 2.0 (2017.12)
-  elif test "$platform" = "amazon linux"; then
-    platform="el"
-    platform_version="7.0"
-  fi
 # Apple OS X
 elif test -f "/usr/bin/sw_vers"; then
   platform="mac_os_x"
@@ -110,7 +97,13 @@ elif test -f "/etc/os-release"; then
     . $CISCO_RELEASE_INFO
   fi
 
-  platform=$ID
+  # return amazon on amazon linux systems
+  if test "$ID" = "amzn"; then
+    platform="amazon"
+  else
+    platform=$ID
+  fi
+
   platform_version=$VERSION
 fi
 

--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -55,6 +55,14 @@ elif test -f "/etc/redhat-release"; then
     platform="el"
   fi
 
+# detect amazon linux 2013/2014 which lack /etc/os-release
+elif test -f "/etc/system-release"; then
+  platform=`sed 's/^\(.\+\) release.\+/\1/' /etc/system-release | tr '[A-Z]' '[a-z]'`
+  platform_version=`sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/system-release | tr '[A-Z]' '[a-z]'`
+  if test "$platform" = "amazon linux ami"; then
+    platform="amazon"
+  fi
+
 # Apple OS X
 elif test -f "/usr/bin/sw_vers"; then
   platform="mac_os_x"
@@ -97,7 +105,7 @@ elif test -f "/etc/os-release"; then
     . $CISCO_RELEASE_INFO
   fi
 
-  # return amazon on amazon linux systems
+  # return amazon on amazon linux 2015+ systems which have /etc/os-release
   if test "$ID" = "amzn"; then
     platform="amazon"
   else


### PR DESCRIPTION
Our current detection of Amazon Linux 2 is broken. We relied on parsing out /etc/system-release contents and expecting a pretty specific text string format. Amazon changed this between the RC and the final release and broke installation on Amazon Linux 2. Total bummer.

This PR removes the logic to remap Amazon to EL 6 or 7 and instead detects Amazon via /etc/os-release and looks up the exact version from that file. This means instead of having install.sh request an download file for EL 6 it will request amazon 2018.03. This lets us handle the remapping directly in omnitruck and it also gives us the ability to actually see from the server side when users are requesting installs on Amazon Linux, which would be pretty handy to know.

Furthermore moving the logic out of install.sh and into omnitruck makes it really easy for us to push out a fix in the future. Some users cache install.sh locally and even if we fix the code on our site they're still using the old logic. If install.sh doesn't do as much heavy lifting and instead relies on omnitruck for that we can easily push out logic updates to omnitruck in the event that something like Amazon Linux 3 comes out that needs to make to Redhat 8.

Note: This will require a PR to omnitruck to handle the mapping correctly.

Signed-off-by: Tim Smith <tsmith@chef.io>