### PR TITLE
Switch to VERSION_ID to detect the Amazon Linux Release

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -63,7 +63,7 @@ elif test -f "/etc/system-release"; then
     platform="amazon"
     if test -f "/etc/os-release"; then
       . /etc/os-release
-      platform_version=$VERSION
+      platform_version=$VERSION_ID
     fi
   esac
 


### PR DESCRIPTION
VERSION is a nice version string except on the RC release of Amazon Linux 2 where it's "2.0 (2017.12)". By switching to VERSION_ID we get "2.0" or "2" everywhere and this allows us to fetch the correct release.

Signed-off-by: Tim Smith <tsmith@chef.io>