### PR TITLE
Rename suse platform to opensuseleap

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -97,7 +97,7 @@ elif test -f "/etc/SuSE-release"; then
       platform="sles"
       platform_version=`awk '/^VERSION/ {V = $3}; /^PATCHLEVEL/ {P = $3}; END {print V "." P}' /etc/SuSE-release`
   else
-      platform="suse"
+      platform="opensuseleap"
       platform_version=`awk '/^VERSION =/ { print $3 }' /etc/SuSE-release`
   fi
 elif test "x$os" = "xFreeBSD"; then

--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -156,7 +156,7 @@ case $platform in
   "sles")
     platform_version=$major_version
     ;;
-  "suse")
+  "opensuseleap")
     platform_version=$major_version
     ;;
 esac


### PR DESCRIPTION
This aligns the names we use in the install script with ohai. We're already remapping suse to sles in omnitruck. I added a remap for opensuseleap to sles in a PR there. This is a baby step towards a single list of platform names.

Signed-off-by: Tim Smith <tsmith@chef.io>