### PR TITLE
Update install scripts to not mention Omnibus

### DIFF
--- a/support/install_command.ps1
+++ b/support/install_command.ps1
@@ -65,7 +65,7 @@ Function Verify-SHA256($path, $sha256) {
 }
 
 Function Install-Chef($msi, $chef_omnibus_root) {
-  Log "Installing Chef Omnibus package $msi"
+  Log "Installing Chef package $msi"
   $installingChef = $True
   $installAttempts = 0
   while ($installingChef) {
@@ -194,7 +194,7 @@ Function Unresolve-Path($p) {
 $chef_omnibus_root = Unresolve-Path $chef_omnibus_root
 
 if (Check-UpdateChef $chef_omnibus_root $version) {
-  Write-Host "-----> Installing Chef Omnibus ($pretty_version)"
+  Write-Host "-----> Installing Chef $pretty_version package"
   if ($chef_metadata_url -ne $null) {
     $url, $sha256 = Get-ChefMetadata "$chef_metadata_url"
   } else {
@@ -210,5 +210,5 @@ if (Check-UpdateChef $chef_omnibus_root $version) {
   }
   Install-Chef $msi $chef_omnibus_root
 } else {
-  Write-Host "-----> Chef Omnibus installation detected ($pretty_version)"
+  Write-Host "-----> Chef installation detected ($pretty_version)"
 }

--- a/support/install_command.sh
+++ b/support/install_command.sh
@@ -206,7 +206,7 @@ unable_to_download() {
 main() {
   should_update_chef "$chef_omnibus_root" "$version"
   if test $? -eq 0; then
-    echo "-----> Installing Chef Omnibus (${pretty_version})";
+    echo "-----> Installing Chef ${pretty_version} package";
 
     # solaris 10 lacks recent enough credentials, so http url is used
     platform="`/usr/bin/uname -s 2>/dev/null`";
@@ -218,7 +218,7 @@ main() {
     do_download "$chef_omnibus_url" /tmp/install.sh;
     $sudo_sh /tmp/install.sh $install_flags;
   else
-    echo "-----> Chef Omnibus installation detected (${pretty_version})";
+    echo "-----> Chef installation detected (${pretty_version})";
   fi
 }
 


### PR DESCRIPTION
We've scrubbed the docs site for the term omnibus since it doesn't mean
anything out of Chef. This will help us to scrub it from every Test
Kitchen run.

Signed-off-by: Tim Smith <tsmith@chef.io>