### PR TITLE
Bug when concatenating http_proxy environment variables

### DIFF
--- a/lib/mixlib/install/util.rb
+++ b/lib/mixlib/install/util.rb
@@ -66,10 +66,13 @@ module Mixlib
             env << Util.shell_env_var("https_proxy", opts[:https_proxy], powershell)
             env << Util.shell_env_var("HTTPS_PROXY", opts[:https_proxy], powershell)
           end
+          unless env.empty?
+            code = env.join("\n").concat("\n").concat(code)
+          end
           if powershell
-            env.join("\n").concat("\n").concat(code)
+            "\n" + code
           else
-            Util.wrap_command(env.join("\n").concat("\n").concat(code))
+            Util.wrap_command(code)
           end
         end
 

--- a/spec/unit/mixlib/install/util_spec.rb
+++ b/spec/unit/mixlib/install/util_spec.rb
@@ -99,12 +99,15 @@ describe Mixlib::Install::Util do
         expect(Mixlib::Install::Util.wrap_shell("some shell code", true)).to eql("\nsome shell code")
       end
       it "on unix" do
-        expect(Mixlib::Install::Util.wrap_shell("some shell code", false)).to eql("sh -c '\n\nsome shell code\n'")
+        expect(Mixlib::Install::Util.wrap_shell("some shell code", false)).to eql("sh -c '\nsome shell code\n'")
       end
     end
 
     describe "with an http proxy" do
       let(:opts) { { http_proxy: "http://localhost:4321" } }
+      it "on windows" do
+        expect(Mixlib::Install::Util.wrap_shell("some shell code", true, opts)).to eql("\n$env:http_proxy = \"http://localhost:4321\"\n$env:HTTP_PROXY = \"http://localhost:4321\"\nsome shell code")
+      end
       it "on unix" do
         expect(Mixlib::Install::Util.wrap_shell("some shell code", false, opts)).to eql("sh -c '\nhttp_proxy=\"http://localhost:4321\"; export http_proxy\nHTTP_PROXY=\"http://localhost:4321\"; export HTTP_PROXY\nsome shell code\n'")
       end
@@ -112,6 +115,9 @@ describe Mixlib::Install::Util do
 
     describe "with an https proxy" do
       let(:opts) { { https_proxy: "https://localhost:4321" } }
+      it "on windows" do
+        expect(Mixlib::Install::Util.wrap_shell("some shell code", true, opts)).to eql("\n$env:https_proxy = \"https://localhost:4321\"\n$env:HTTPS_PROXY = \"https://localhost:4321\"\nsome shell code")
+      end
       it "on unix" do
         expect(Mixlib::Install::Util.wrap_shell("some shell code", false, opts)).to eql("sh -c '\nhttps_proxy=\"https://localhost:4321\"; export https_proxy\nHTTPS_PROXY=\"https://localhost:4321\"; export HTTPS_PROXY\nsome shell code\n'")
       end


### PR DESCRIPTION
### Description

This caused an issue for a customer trying to install chef-client
through a proxy. Their 'install.ps1' script ended up with a line in it
like 'previous_line=fooHTTP_PROXY=bar'. Their HTTP_PROXY was not set
and chef-client could not be downloaded.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
