### PR TITLE
Add support for armv7l

### DIFF
--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -29,6 +29,7 @@ module Mixlib
 
       SUPPORTED_ARCHITECTURES = %w{
         aarch64
+        armv7l
         i386
         powerpc
         ppc64


### PR DESCRIPTION
Add also armv7l support
it looks like it makes the testsuite pass on Ubuntu armhf builders...