### PR TITLE
Set the proxy environment variables using bourne shell syntax

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/proxy_env.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/proxy_env.sh
@@ -5,24 +5,32 @@
 
 if test "x$https_proxy" != "x"; then
   echo "setting https_proxy: $https_proxy"
-  export HTTPS_PROXY=$https_proxy
-  export https_proxy=$https_proxy
+  HTTPS_PROXY=$https_proxy
+  https_proxy=$https_proxy
+  export HTTPS_PROXY
+  export https_proxy
 fi
 
 if test "x$http_proxy" != "x"; then
   echo "setting http_proxy: $http_proxy"
-  export HTTP_PROXY=$http_proxy
-  export http_proxy=$http_proxy
+  HTTP_PROXY=$http_proxy
+  http_proxy=$http_proxy
+  export HTTP_PROXY
+  export http_proxy
 fi
 
 if test "x$ftp_proxy" != "x"; then
   echo "setting ftp_proxy: $ftp_proxy"
-  export FTP_PROXY=$ftp_proxy
-  export ftp_proxy=$ftp_proxy
+  FTP_PROXY=$ftp_proxy
+  ftp_proxy=$ftp_proxy
+  export FTP_PROXY
+  export ftp_proxy
 fi
 
 if test "x$no_proxy" != "x"; then
   echo "setting no_proxy: $no_proxy"
-  export NO_PROXY=$no_proxy
-  export no_proxy=$no_proxy
+  NO_PROXY=$no_proxy
+  no_proxy=$no_proxy
+  export NO_PROXY
+  export no_proxy
 fi

--- a/spec/unit/mixlib/install/generator_spec.rb
+++ b/spec/unit/mixlib/install/generator_spec.rb
@@ -43,6 +43,15 @@ context "Mixlib::Install::Generator", :vcr do
       expect(install_script).to start_with("#!/bin/sh")
       expect(install_script).to include('install_file $filetype "$download_filename"')
     end
+    it "sets http proxy environment variables" do
+      expect(install_script).to match(/^\s*HTTPS_PROXY=\S+/)
+    end
+    it "exports proxy environment variables" do
+      expect(install_script).to match(/^\s*export\s+HTTPS_PROXY$/)
+    end
+    it "does not export and set proxy environment variables using a single line" do
+      expect(install_script).not_to match(/^\s*export\s+\S+=\S+/)
+    end
   end
 
   context "for :unstable channel" do


### PR DESCRIPTION
Proxy_env.sh was using bash syntax to export environment variables
bootstrapping the chef-client on Solaris servers failed due to
syntax errors.

### Description

The environment variables settings don't work with /bin/sh.  I'm trying to get knife bootstraps to work with Solaris clients.

### Issues Resolved



### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
