### PR TITLE
Use a grep command compatible with solaris 10 and older greps

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -25,7 +25,7 @@
 machine=`uname -m`
 os=`uname -s`
 
-if test -f "/etc/lsb-release" && grep -q DISTRIB_ID /etc/lsb-release && ! grep -q wrlinux /etc/lsb-release; then
+if test -f "/etc/lsb-release" && grep DISTRIB_ID /etc/lsb-release >/dev/null && ! grep wrlinux /etc/lsb-release >/dev/null; then
   platform=`grep DISTRIB_ID /etc/lsb-release | cut -d "=" -f 2 | tr '[A-Z]' '[a-z]'`
   platform_version=`grep DISTRIB_RELEASE /etc/lsb-release | cut -d "=" -f 2`
 
@@ -84,7 +84,7 @@ elif test -f "/usr/bin/sw_vers"; then
   fi
 elif test -f "/etc/release"; then
   machine=`/usr/bin/uname -p`
-  if grep -q SmartOS /etc/release; then
+  if grep SmartOS /etc/release >/dev/null; then
     platform="smartos"
     platform_version=`grep ^Image /etc/product | awk '{ print $3 }'`
   else
@@ -92,7 +92,7 @@ elif test -f "/etc/release"; then
     platform_version=`/usr/bin/uname -r`
   fi
 elif test -f "/etc/SuSE-release"; then
-  if grep -q 'Enterprise' /etc/SuSE-release;
+  if grep 'Enterprise' /etc/SuSE-release >/dev/null;
   then
       platform="sles"
       platform_version=`awk '/^VERSION/ {V = $3}; /^PATCHLEVEL/ {P = $3}; END {print V "." P}' /etc/SuSE-release`

--- a/spec/unit/mixlib/install_spec.rb
+++ b/spec/unit/mixlib/install_spec.rb
@@ -223,6 +223,10 @@ context "Mixlib::Install" do
     it "should return platform_detection.sh" do
       expect(script).to include('echo "$platform $platform_version $machine"')
     end
+
+    it "should return platform_detection.sh using grep without -q" do
+      expect(script).not_to include("grep.*-q")
+    end
   end
 
   context "detect_platform_ps1" do


### PR DESCRIPTION
Grep on some solaris servers doesn't support the -q option.

Signed-off-by: markgibbons <mark.gibbons@nordstrom.com>

### Description

Old versions of grep don't support the -q option.  When trying to discover the type of server
a lowest common denominator approach is probably needed.

### Issues Resolved

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG