### PR TITLE
Properly identify Windows 2019 in the install.ps1

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
@@ -3,11 +3,12 @@
 
 function Get-PlatformVersion {
   switch -regex ((Get-Win32OS).version) {
-    '10\.0\.\d+' {$platform_version = '2016'}
-    '6\.3\.\d+'  {$platform_version = '2012r2'}
-    '6\.2\.\d+'  {$platform_version = '2012'}
-    '6\.1\.\d+'  {$platform_version = '2008r2'}
-    '6\.0\.\d+'  {$platform_version = '2008'}
+    '10\.0\.\d+'   {$platform_version = '2016'}
+    '10\.0\.17\d+' {$platform_version = '2019'}
+    '6\.3\.\d+'    {$platform_version = '2012r2'}
+    '6\.2\.\d+'    {$platform_version = '2012'}
+    '6\.1\.\d+'    {$platform_version = '2008r2'}
+    '6\.0\.\d+'    {$platform_version = '2008'}
   }
 
   if(Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Server\ServerLevels') {


### PR DESCRIPTION
Right now we're identifying Windows 2019 systems as being 2016. This isn't a critical issue as our 2016 and 2019 packages are actually the same thing, but it would be good to properly identify the OS we're on. At the very least this gets us better usage data for Windows releases. The unfortunate thing is that Microsoft hasn't bumped the NT major or minor versions for 2019. Instead, they just pumped the patch (build) of the release. 2016 is 14xxx and 2019 is 17xxx. The last match wins in these switch statements so if we see a 17xxx build then identify it as 2019. 18000 is Windows 10 so I don't see them releasing a 2019 build that is in the 18000 range. If they do for some reason we'll identify these as 2016, which would be fine. I think that's the overly cautious route to take unless someone has concerns.

Signed-off-by: Tim Smith <tsmith@chef.io>