### PR TITLE
Shorten path names for Windows

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -39,6 +39,7 @@ steps:
 
 - label: run-specs-windows
   command:
+    - reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 0x1 /f
     - bundle install --jobs=7 --retry=3 --without docs debug
     - bundle exec rake
   expeditor:


### PR DESCRIPTION
Avoid path name failures on Windows

Signed-off-by: Tim Smith <tsmith@chef.io>