### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -20,11 +20,11 @@
 require "mixlib/versioning"
 require "mixlib/shellout"
 
-require "mixlib/install/backend"
-require "mixlib/install/options"
-require "mixlib/install/generator"
-require "mixlib/install/generator/bourne"
-require "mixlib/install/generator/powershell"
+require_relative "install/backend"
+require_relative "install/options"
+require_relative "install/generator"
+require_relative "install/generator/bourne"
+require_relative "install/generator/powershell"
 
 module Mixlib
   class Install

--- a/lib/mixlib/install/backend.rb
+++ b/lib/mixlib/install/backend.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "mixlib/install/backend/package_router"
+require_relative "backend/package_router"
 
 module Mixlib
   class Install

--- a/lib/mixlib/install/backend/base.rb
+++ b/lib/mixlib/install/backend/base.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "mixlib/install/util"
+require_relative "../util"
 
 module Mixlib
   class Install

--- a/lib/mixlib/install/backend/package_router.rb
+++ b/lib/mixlib/install/backend/package_router.rb
@@ -17,12 +17,12 @@
 #
 
 require "json"
-require "mixlib/install/artifact_info"
-require "mixlib/install/backend/base"
-require "mixlib/install/product"
-require "mixlib/install/product_matrix"
-require "mixlib/install/util"
-require "mixlib/install/dist"
+require_relative "../artifact_info"
+require_relative "base"
+require_relative "../product"
+require_relative "../product_matrix"
+require_relative "../util"
+require_relative "../dist"
 require "mixlib/versioning"
 require "net/http"
 

--- a/lib/mixlib/install/cli.rb
+++ b/lib/mixlib/install/cli.rb
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-require "mixlib/install"
+require_relative "../install"
 require "thor"
 
 module Mixlib
@@ -22,7 +22,7 @@ module Mixlib
 
       desc "version", "print mixlib-install version"
       def version
-        require "mixlib/install/version"
+        require_relative "version"
         say Mixlib::Install::VERSION
       end
 

--- a/lib/mixlib/install/generator.rb
+++ b/lib/mixlib/install/generator.rb
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-require "mixlib/install/generator/bourne"
-require "mixlib/install/generator/powershell"
+require_relative "generator/bourne"
+require_relative "generator/powershell"
 
 module Mixlib
   class Install

--- a/lib/mixlib/install/generator/base.rb
+++ b/lib/mixlib/install/generator/base.rb
@@ -17,8 +17,8 @@
 
 require "erb"
 require "ostruct"
-require "mixlib/install/util"
-require "mixlib/install/dist"
+require_relative "../util"
+require_relative "../dist"
 
 module Mixlib
   class Install

--- a/lib/mixlib/install/generator/bourne.rb
+++ b/lib/mixlib/install/generator/bourne.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "mixlib/install/generator/base"
+require_relative "base"
 
 module Mixlib
   class Install

--- a/lib/mixlib/install/generator/powershell.rb
+++ b/lib/mixlib/install/generator/powershell.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "mixlib/install/generator/base"
+require_relative "base"
 
 module Mixlib
   class Install

--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -16,9 +16,9 @@
 # limitations under the License.
 #
 
-require "mixlib/install/product"
-require "mixlib/install/product_matrix"
-require "mixlib/install/util"
+require_relative "product"
+require_relative "product_matrix"
+require_relative "util"
 require "mixlib/versioning"
 
 module Mixlib

--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -16,7 +16,7 @@
 #
 
 require "mixlib/versioning"
-require "mixlib/install/dist"
+require_relative "dist"
 
 module Mixlib
   class Install

--- a/lib/mixlib/install/product_matrix.rb
+++ b/lib/mixlib/install/product_matrix.rb
@@ -1,4 +1,4 @@
-require "mixlib/install/product"
+require_relative "product"
 
 #
 # If you are making a change to PRODUCT_MATRIX, please make sure

--- a/lib/mixlib/install/script_generator.rb
+++ b/lib/mixlib/install/script_generator.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-require "mixlib/install/util"
-require "mixlib/install/generator/powershell"
+require_relative "util"
+require_relative "generator/powershell"
 require "cgi"
 
 module Mixlib

--- a/lib/mixlib/install/util.rb
+++ b/lib/mixlib/install/util.rb
@@ -126,7 +126,7 @@ module Mixlib
         # @param name [Array] headers
         # @return [String] generated user-agent string
         def user_agent_string(headers)
-          require "mixlib/install/version"
+          require_relative "version"
           user_agents = %W{mixlib-install/#{Mixlib::Install::VERSION}}
           user_agents << headers
           # Ensure that if the default user agent is aleady set it doesn't get duplicated


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>