### PR TITLE
Map arm64 architecture to aarch64

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -163,6 +163,9 @@ esac
 
 # normalize the architecture we detected
 case $machine in
+  "arm64"|"aarch64")
+    machine="aarch64"
+    ;;
   "x86_64"|"amd64"|"x64")
     machine="x86_64"
     ;;

--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -30,7 +30,6 @@ module Mixlib
 
       SUPPORTED_ARCHITECTURES = %w{
         aarch64
-        arm64
         armv7l
         i386
         powerpc

--- a/lib/mixlib/install/util.rb
+++ b/lib/mixlib/install/util.rb
@@ -162,6 +162,8 @@ module Mixlib
           case architecture
           when "amd64"
             "x86_64"
+          when "arm64"
+            "aarch64"
           when "i86pc", "i686"
             "i386"
           when "sun4u", "sun4v"


### PR DESCRIPTION
Ubuntu nodes map architecutre `uname -i` to aarch64 and `dpkg --print-architecture` to arm64 so we need this mapping reflect here

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

Ubuntu nodes map architecutre `uname -i` to aarch64 and `dpkg --print-architecture` to arm64 so we need this mapping reflect here

## Description
Map arm64 architecture to aarch64

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
