### PR TITLE
Use the VERSION_ID variable by default in /etc/os-release

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -96,7 +96,7 @@ elif test -f "/etc/SuSE-release"; then
   then
       platform="sles"
       platform_version=`awk '/^VERSION/ {V = $3}; /^PATCHLEVEL/ {P = $3}; END {print V "." P}' /etc/SuSE-release`
-  else
+  else # opensuse 43 only. 15 ships with /etc/os-release only
       platform="opensuseleap"
       platform_version=`awk '/^VERSION =/ { print $3 }' /etc/SuSE-release`
   fi
@@ -114,7 +114,14 @@ elif test -f "/etc/os-release"; then
   fi
 
   platform=$ID
-  platform_version=$VERSION
+
+  # VERSION_ID is always the preferred variable to use, but not
+  # every distro has it so fallback to VERSION
+  if test "x$VERSION_ID" != "x"; then
+    platform_version=$VERSION_ID
+  else
+    platform_version=$VERSION
+  fi
 fi
 
 if test "x$platform" = "x"; then


### PR DESCRIPTION
This variable is the machine readable version ID for tools like our install script. The VERSION variable often includes friendly values like this: "7.5 (Maipo)".

We're already doing this for RHEL platforms, but currently we pull in VERSION on modern opensuse platforms and others, which breaks installs via install.sh.

### Lack VERSION (or version without strings in it), but have VERSION_ID:

- alpine - https://github.com/chef/os_release/blob/master/alpine_3_8
- clearos - https://github.com/chef/os_release/blob/master/clearos_7
- cumulus - https://github.com/chef/os_release/blob/master/cumulus_3_7
- debian - https://github.com/chef/os_release/blob/master/debian_7
- elementary - https://github.com/chef/os_release/blob/master/elementary_5
- fedora - https://github.com/chef/os_release/blob/master/fedora_28
- linuxmint - https://github.com/chef/os_release/blob/master/linuxmint_19
- nixos - https://github.com/chef/os_release/blob/master/nixos
- raspian - https://github.com/chef/os_release/blob/master/raspbian_10
- redhat - https://github.com/chef/os_release/blob/master/redhat_7
- scientific - https://github.com/chef/os_release/blob/master/scientific_7
- sled 12 - https://github.com/chef/os_release/blob/master/sled_12_3
- sles 12 - https://github.com/chef/os_release/blob/master/sles_12_3
- sles-sap 12 - https://github.com/chef/os_release/blob/master/sles_sap_12_1
- ubuntu - https://github.com/chef/os_release/blob/master/ubuntu_1404
- XBian - https://github.com/chef/os_release/blob/master/xbian

### Have VERSION, but not VERSION_ID:

- Antergos - https://github.com/chef/os_release/blob/master/antergos
- xenserver - https://github.com/chef/os_release/blob/master/xenserver_7_6

### Have neither:

- arch - https://github.com/chef/os_release/blob/master/arch
- archarm - https://github.com/chef/os_release/blob/master/archarm
- gentoo - https://github.com/chef/os_release/blob/master/gentoo
- manjaro - https://github.com/chef/os_release/blob/master/manjaro
- nexus7 - https://github.com/chef/os_release/blob/master/nexus_7

Signed-off-by: Tim Smith <tsmith@chef.io>