### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -18,7 +18,7 @@
 #
 
 require "mixlib/versioning"
-require "mixlib/shellout"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 
 require_relative "install/backend"
 require_relative "install/options"

--- a/lib/mixlib/install/backend/package_router.rb
+++ b/lib/mixlib/install/backend/package_router.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-require "json"
+require "json" unless defined?(JSON)
 require_relative "../artifact_info"
 require_relative "base"
 require_relative "../product"
@@ -24,7 +24,7 @@ require_relative "../product_matrix"
 require_relative "../util"
 require_relative "../dist"
 require "mixlib/versioning"
-require "net/http"
+require "net/http" unless defined?(Net::HTTP)
 
 module Mixlib
   class Install

--- a/lib/mixlib/install/cli.rb
+++ b/lib/mixlib/install/cli.rb
@@ -13,7 +13,7 @@
 #
 
 require_relative "../install"
-require "thor"
+require "thor" unless defined?(Thor)
 
 module Mixlib
   class Install

--- a/lib/mixlib/install/generator/base.rb
+++ b/lib/mixlib/install/generator/base.rb
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-require "erb"
-require "ostruct"
+require "erb" unless defined?(Erb)
+require "ostruct" unless defined?(OpenStruct)
 require_relative "../util"
 require_relative "../dist"
 


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs

Signed-off-by: Tim Smith <tsmith@chef.io>