### PR TITLE
Add linux path, variabilize script_generator and install

### DIFF
--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -25,6 +25,7 @@ require_relative "install/options"
 require_relative "install/generator"
 require_relative "install/generator/bourne"
 require_relative "install/generator/powershell"
+require_relative "install/dist"
 
 module Mixlib
   class Install
@@ -119,7 +120,7 @@ module Mixlib
       # This only works for chef and chefdk but they are the only projects
       # we are supporting as of now.
       if options.for_ps1?
-        "$env:systemdrive\\opscode\\#{options.product_name}"
+        "$env:systemdrive\\#{Mixlib::Install::Dist::WINDOWS_INSTALL_DIR}\\#{options.product_name}"
       else
         "/opt/#{options.product_name}"
       end
@@ -136,7 +137,7 @@ module Mixlib
       # chef-server -> /opt/opscode). But this is OK for now since
       # chef & chefdk are the only supported products.
       version_manifest_file = if options.for_ps1?
-                                "$env:systemdrive\\opscode\\#{options.product_name}\\version-manifest.json"
+                                "$env:systemdrive\\#{Mixlib::Install::Dist::WINDOWS_INSTALL_DIR}\\#{options.product_name}\\version-manifest.json"
                               else
                                 "/opt/#{options.product_name}/version-manifest.json"
                               end

--- a/lib/mixlib/install/dist.rb
+++ b/lib/mixlib/install/dist.rb
@@ -24,6 +24,8 @@ module Mixlib
       MACOS_VOLUME = "chef_software".freeze
       # Windows install directory name
       WINDOWS_INSTALL_DIR = "opscode".freeze
+      # Linux install directory name
+      LINUX_INSTALL_DIR = "/opt"
     end
   end
 end

--- a/lib/mixlib/install/script_generator.rb
+++ b/lib/mixlib/install/script_generator.rb
@@ -19,6 +19,7 @@
 
 require_relative "util"
 require_relative "generator/powershell"
+require_relative "dist"
 require "cgi"
 
 module Mixlib
@@ -83,9 +84,9 @@ module Mixlib
         @sudo_command = "sudo -E"
 
         @root = if powershell
-                  "$env:systemdrive\\opscode\\chef"
+                  "$env:systemdrive\\#{Mixlib::Install::Dist::WINDOWS_INSTALL_DIR}\\#{Mixlib::Install::Dist::DEFAULT_PRODUCT}"
                 else
-                  "/opt/chef"
+                  "#{Mixlib::Install::Dist::LINUX_INSTALL_DIR}/#{Mixlib::Install::Dist::DEFAULT_PRODUCT}"
                 end
 
         parse_opts(opts)


### PR DESCRIPTION
Signed-off-by: Tensibai Zhaoying <tensibai@iabis.net>

## Description
Mixlib-install still had a few places not variabilized for distribution

## Related Issue
No issue done, seems falling in the obvious fix category.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally **and 2 fails but they are unrelated to the change**.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
