### PR TITLE
Ensure platform detection logic supports Apple Silicon

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -76,12 +76,6 @@ elif test -f "/usr/bin/sw_vers"; then
   platform="mac_os_x"
   # Matching the tab-space with sed is error-prone
   platform_version=`sw_vers | awk '/^ProductVersion:/ { print $2 }' | cut -d. -f1,2`
-
-  # x86_64 Apple hardware often runs 32-bit kernels (see OHAI-63)
-  x86_64=`sysctl -n hw.optional.x86_64`
-  if test $x86_64 -eq 1; then
-    machine="x86_64"
-  fi
 elif test -f "/etc/release"; then
   machine=`/usr/bin/uname -p`
   if grep SmartOS /etc/release >/dev/null; then


### PR DESCRIPTION
This updates our platform detection check on macOS to just return the
result of running `uname -m` which properly returns `x86_64` or `arm64`
depending on which type of Mac hardware the check is run on. Full output
details on chef/omnitruck#482

Signed-off-by: Seth Chisamore <schisamo@chef.io>
