### PR TITLE
Allow to extend the supported products of mixlib-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,25 @@ Bourne install script (`install.sh`) supports `http_proxy`, `https_proxy`, `ftp_
 
 Powershell install script (`install.ps1`) supports `http_proxy` passed as a key to `install_command_options`.
 
+
+### Extending for other products
+
+Create a ruby file in your application and use the product DSL like this (see [product.rb](lib/mixlib/install/product.rb) for available properties):
+
+```
+product "cinc" do
+  product_name "Cinc Infra Client"
+  package_name "cinc-client"
+  api_url "https://packages.cinc.sh"
+end
+```
+
+Then set an environment variable to load them like this on linux:
+
+`export EXTRA_PRODUCTS_FILE=/path/to/your/file.rb`
+
+Calls to mixlib-install now allow to target your new product, assuming the api_url match pacakges api for `/<channel>/<product>/versions` and `/<channel>/<product>/<version>/artifacts` endpoints.
+
 ## Development
 VCR is a tool that helps cache and replay http responses. When these responses change or when you add more tests you might need to update cached responses. Check out [spec_helper.rb](https://github.com/chef/mixlib-install/blob/master/spec/spec_helper.rb) for instructions on how to do this.
 

--- a/lib/mixlib/install/backend/package_router.rb
+++ b/lib/mixlib/install/backend/package_router.rb
@@ -30,7 +30,6 @@ module Mixlib
   class Install
     class Backend
       class PackageRouter < Base
-        ENDPOINT = Mixlib::Install::Dist::PRODUCT_ENDPOINT.freeze
 
         COMPAT_DOWNLOAD_URL_ENDPOINT = "http://packages.chef.io".freeze
 
@@ -269,7 +268,7 @@ EOF
         end
 
         def endpoint
-          @endpoint ||= ENV.fetch("PACKAGE_ROUTER_ENDPOINT", ENDPOINT)
+          @endpoint ||= PRODUCT_MATRIX.lookup(options.product_name, options.product_version).api_url
         end
 
         def omnibus_project

--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -36,6 +36,7 @@ module Mixlib
         :omnibus_project,
         :github_repo,
         :downloads_product_page_url,
+        :api_url,
       ]
 
       #
@@ -86,6 +87,8 @@ module Mixlib
           "#{Mixlib::Install::Dist::DOWNLOADS_PAGE}/#{product_key}"
         when :github_repo
           "#{Mixlib::Install::Dist::GITHUB_ORG}/#{product_key}"
+        when :api_url
+          ENV.fetch("PACKAGE_ROUTER_ENDPOINT", Mixlib::Install::Dist::PRODUCT_ENDPOINT)
         else
           nil
         end

--- a/spec/fixtures/extra/extra_distributions.rb
+++ b/spec/fixtures/extra/extra_distributions.rb
@@ -1,0 +1,5 @@
+product "cinc" do
+  product_name "Cinc Infra Client"
+  package_name "cinc-client"
+  api_url "https://packages.cinc.sh"
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require "climate_control"
 
 # load version manifest support path
 VERSION_MANIFEST_DIR = File.expand_path("../support/version_manifests", __FILE__)
+EXTRA_FILE = File.join(File.dirname(__FILE__), "/fixtures/extra/extra_distributions.rb")
 
 RSpec.configure do |config|
   config.filter_run focus: true

--- a/spec/unit/mixlib/install/backend_spec.rb
+++ b/spec/unit/mixlib/install/backend_spec.rb
@@ -57,7 +57,7 @@ context "Mixlib::Install::Backend", :vcr do
         url.include?("solaris2/5.9")
       expect(url).to include(Mixlib::Install::Backend::PackageRouter::COMPAT_DOWNLOAD_URL_ENDPOINT)
     else
-      expect(url).to include(Mixlib::Install::Backend::PackageRouter::ENDPOINT)
+      expect(url).to include(Mixlib::Install::Dist::PRODUCT_ENDPOINT)
     end
   end
 

--- a/spec/unit/mixlib/install/with_extra_products_spec.rb
+++ b/spec/unit/mixlib/install/with_extra_products_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+require "mixlib/install"
+require "mixlib/install/product"
+
+context "With extra distribution Environment variable" do
+  let(:mi) do
+    with_modified_env(EXTRA_PRODUCTS_FILE: EXTRA_FILE) do
+      Mixlib::Install.new(product_name: "cinc", channel: :stable)
+    end
+  end
+
+  it "Doesn't raise error" do
+    expect { mi }.not_to raise_error
+  end
+
+  it "Should include cinc as allowed product" do
+    expect(mi.options.supported_product_names).to include("cinc")
+  end
+
+  it "Should get the product specific URL" do
+    expect(PRODUCT_MATRIX.lookup("cinc").api_url).to match("https://packages.cinc.sh")
+  end
+end


### PR DESCRIPTION
Signed-off-by: Tensibai <tensibai@iabis.net>

## Description
Mixlib-install doesn't have a native way to add supported products out of editing the product_matrix.rb file.
This make things complex to address Chef and other distribution install from the same tool (namely for cinc for what I'm insterested about).

This proposal allow to specify an extra file using the Product DSL to add products to the matrix with their own omnitruck url.

## Related Issue
https://github.com/chef/mixlib-install/issues/339

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
