### PR TITLE
Fix issue with bypass list containing * entries

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
@@ -82,10 +82,18 @@ function Get-WebContentOnFullNet {
   
 
   if($bypassList -ne $null){
-     
-	 $bypassList = $bypassList.split(",")
-	 $proxy.BypassList = $byPassList
-  }
+  	$bypassList = $bypassList.split(",")
+    ForEach ($bypassListItem in $bypassList){
+        try {
+          [regex]$bypassListItem | Out-Null
+        }
+        catch {
+          Write-Warning "Wildcard entry $bypassListItem will be ignored, please use regex"
+          Continue
+        }
+				$proxy.BypassArrayList.Add($bypassListItem)
+			}
+    }
   
   $wc.Proxy = $proxy
 

--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
@@ -78,7 +78,7 @@ function Get-WebContentOnFullNet {
   $wc = new-object System.Net.WebClient
   $wc.Headers.Add("user-agent", "<%= user_agent_string %>")
   $proxy.Address = $env:http_proxy
-  $bypassList = $proxy.BypassList = $env:no_proxy.replace('.', '\.').replace('..', '\..+\.').replace('*', '.+').split(',').Trim()
+  $proxy.BypassList = $env:no_proxy.replace('.', '\.').replace('..', '\..+\.').replace('*', '.+').split(',').Trim()
   $wc.Proxy = $proxy
 
   if ([string]::IsNullOrEmpty($filepath)) {

--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
@@ -78,23 +78,7 @@ function Get-WebContentOnFullNet {
   $wc = new-object System.Net.WebClient
   $wc.Headers.Add("user-agent", "<%= user_agent_string %>")
   $proxy.Address = $env:http_proxy
-  $bypassList = $env:no_proxy
-  
-
-  if($bypassList -ne $null){
-  	$bypassList = $bypassList.split(",")
-    ForEach ($bypassListItem in $bypassList){
-        try {
-          [regex]$bypassListItem | Out-Null
-        }
-        catch {
-          Write-Warning "Wildcard entry $bypassListItem will be ignored, please use regex"
-          Continue
-        }
-				$proxy.BypassArrayList.Add($bypassListItem)
-			}
-    }
-  
+  $bypassList = $proxy.BypassList = $env:no_proxy.replace('.', '\.').replace('..', '\..+\.').replace('*', '.+').split(',').Trim()
   $wc.Proxy = $proxy
 
   if ([string]::IsNullOrEmpty($filepath)) {


### PR DESCRIPTION
## Description
If the no_proxy list contains an entry with an wildcard it throws the following error:
```
Exception setting "BypassList": "parsing "*.chef.io" - Quantifier {x,y} following nothing."
At C:\opscode\chef_upgrade.ps1:121 char:3
+      $proxy.BypassList = $byPassList
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationException
    + FullyQualifiedErrorId : ExceptionWhenSetting
```
## Related Issue
[Issue 330](https://github.com/chef/mixlib-install/issues/330)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
