### PR TITLE
Fall back to Get-WmiObject if Get-CimInstance fails

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
@@ -79,14 +79,14 @@ function Get-WebContentOnFullNet {
   $wc.Headers.Add("user-agent", "<%= user_agent_string %>")
   $proxy.Address = $env:http_proxy
   $bypassList = $env:no_proxy
-  
+
 
   if($bypassList -ne $null){
-     
+
 	 $bypassList = $bypassList.split(",")
 	 $proxy.BypassList = $byPassList
   }
-  
+
   $wc.Proxy = $proxy
 
   if ([string]::IsNullOrEmpty($filepath)) {
@@ -180,9 +180,16 @@ function Get-WMIQuery {
   param ($class)
 
   if(Get-Command -Name Get-CimInstance -ErrorAction SilentlyContinue) {
-    Get-CimInstance $class
+    try{
+      $classObject = Get-CimInstance $class
+      # If the Get-CimInstance command exists but fails due to security settings, try Get-WmiObject.
+    }
+    catch {
+      $classObject = Get-WmiObject $class
+    }
   }
   else {
-    Get-WmiObject $class
+    $classObject = Get-WmiObject $class
   }
+  return $classObject
 }


### PR DESCRIPTION
Signed-off-by: gscho <greg.c.schofield@gmail.com>

Adds a try-catch block to a powershell helper so any failure to get the `win32_operatingsystem` using `Get-CimInstance` will be tried using `Get-WmiObject` immediately after. 

## Description
 
## Related Issue
#347 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
