### PR TITLE
Remove pry-stack-explorer test dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,5 @@ end
 group :debug do
   gem "pry"
   gem "pry-byebug"
-  gem "pry-stack_explorer", "~> 0.4.0" # pin until we drop ruby < 2.6
   gem "rb-readline"
 end


### PR DESCRIPTION
We don't use this and it causes failures in Ruby 2.4 tests

Signed-off-by: Tim Smith <tsmith@chef.io>