### PR TITLE
Update install script warning to not mention desktop

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/install_package.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/install_package.sh
@@ -15,7 +15,7 @@ if test "x$version" = "x" -a "x$CI" != "xtrue"; then
   echo "You are installing a package without a version pin.  If you are installing"
   echo "on production servers via an automated process this is DANGEROUS and you will"
   echo "be upgraded without warning on new releases, even to new major releases."
-  echo "Letting the version float is only appropriate in desktop, test, development or"
+  echo "Letting the version float is only appropriate in test, development or"
   echo "CI/CD environments."
   echo
   echo "WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING"


### PR DESCRIPTION
Signed-off-by: rishichawda <rishichawda@users.noreply.github.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Removed desktop from the list of environments where installing chef without version constraints should be fine. Desktop environments should also pin chef to a specific version.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

resolve #365 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
