### PR TITLE
Add support for detecting Windows Server 2022 platform

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,30 +11,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-ruby-2.4
-  command:
-    - .expeditor/run_linux_tests.sh rake style
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4
-
-- label: run-specs-ruby-2.4
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4
-
-- label: run-specs-ruby-2.5
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5
-
 - label: run-specs-ruby-2.6
   command:
     - .expeditor/run_linux_tests.sh rake

--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
@@ -2,13 +2,17 @@
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12'
 
 function Get-PlatformVersion {
-  switch -regex ((Get-Win32OS).version) {
-    '10\.0\.\d+'   {$platform_version = '2016'}
-    '10\.0\.17\d+' {$platform_version = '2019'}
-    '6\.3\.\d+'    {$platform_version = '2012r2'}
-    '6\.2\.\d+'    {$platform_version = '2012'}
-    '6\.1\.\d+'    {$platform_version = '2008r2'}
-    '6\.0\.\d+'    {$platform_version = '2008'}
+  [version]$osVersion = (Get-Win32OS).version
+
+  $platform_version = switch ($osVersion) {
+    # Windows Server build numbers from: https://betawiki.net/wiki/Microsoft_Windows
+    { $_ -ge [version]'10.0.20145' } { '2022';   break }
+    { $_ -ge [version]'10.0.17609' } { '2019';   break }
+    { $_ -ge [version]'10.0.0'     } { '2016';   break }
+    { $_ -ge [version]'6.3.0'      } { '2012r2'; break }
+    { $_ -ge [version]'6.2.0'      } { '2012';   break }
+    { $_ -ge [version]'6.1.0'      } { '2008r2'; break }
+    { $_ -ge [version]'6.0.0'      } { '2008';   break }
   }
 
   if(Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Server\ServerLevels') {


### PR DESCRIPTION
## Description
Add support for detecting Windows Server 2022 platform

Windows Server 2022 was being detected as 2016. Also made the platform
version detection logic more robust.

Signed-off-by: Joseph Larionov <jlarionov@webmd.net>

## Related Issue
Fixes #376

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
