### PR TITLE
Match on 64 for architecture because of different languages

### DIFF
--- a/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/helpers.ps1.erb
@@ -20,7 +20,7 @@ function Get-PlatformVersion {
 }
 
 function Get-PlatformArchitecture {
-  if ((Get-Win32OS).osarchitecture -like '64-bit') {
+  if ((Get-Win32OS).osarchitecture -match '64') {
     $architecture = 'x86_64'
   } else {
     $architecture = 'i386'


### PR DESCRIPTION
Signed-off-by: Thomas Powell <powell@progress.com>


## Description
Installs on non-English Windows may fail to match on "64-bit" due to localized arch names, but especially non-Latin alphabet versions, e.g., Chinese 64-bit obarchitecture is returned as "64 位"

Match on "64" only for confirming 64-bit install. 32-bit should be the exceptional case at this point, anyway.

## Related Issue
INFC-220 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
