### PR TITLE
IPACK-285 Add product definition for chef client universal package

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,14 +11,6 @@ expeditor:
 
 steps:
 
-- label: run-specs-ruby-2.6
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6
-
 - label: run-specs-ruby-2.7
   command:
     - .expeditor/run_linux_tests.sh rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,2 @@
 AllCops:
-  TargetRubyVersion: 1.9
+  TargetRubyVersion: 2.7

--- a/lib/mixlib/install/product_matrix.rb
+++ b/lib/mixlib/install/product_matrix.rb
@@ -47,6 +47,11 @@ PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
     package_name "chef"
   end
 
+  product "chef-universal" do
+    product_name "Chef Infra Client MacOS Universal"
+    package_name "universal-package"
+  end
+
   product "chef-backend" do
     product_name "Chef Backend"
     package_name "chef-backend"

--- a/spec/unit/mixlib/install/product_spec.rb
+++ b/spec/unit/mixlib/install/product_spec.rb
@@ -137,6 +137,7 @@ context "PRODUCT_MATRIX" do
     angrychef
     automate
     chef
+    chef-universal
     chef-backend
     chef-server
     chef-server-ha-provisioning


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
Add product definition for chef client universal package. A more accurate approach might be to introduce a virtual `universal` architecture and have the package made available alongside macos architecture specific installers for chef-client. This would need changes in multiple places though. So opted for a somewhat independent approach that defines universal package as a separate product to be made available via omnitruck.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
