### PR TITLE
Fix verification tests script failure

### DIFF
--- a/.expeditor/run_windows_tests.ps1
+++ b/.expeditor/run_windows_tests.ps1
@@ -4,10 +4,10 @@ $ErrorActionPreference = "Stop"
 
 Write-Output "--- Bundle install"
 
-bundle config set --local path vendor/bundle
-If ($lastexitcode -ne 0) { Exit $lastexitcode }
+# bundle config set --local path vendor/cache
+# If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
-bundle install --jobs=7 --retry=3
+bundle install --redownload --no-cache --retry=3
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "--- Bundle Execute"

--- a/.expeditor/run_windows_tests.ps1
+++ b/.expeditor/run_windows_tests.ps1
@@ -7,7 +7,10 @@ Write-Output "--- Bundle install"
 bundle config --local path vendor/bundle
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
-bundle install --jobs=7 --retry=3
+gem update -N
+gem install bundler
+
+bundle install --retry=3
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "--- Bundle Execute"

--- a/.expeditor/run_windows_tests.ps1
+++ b/.expeditor/run_windows_tests.ps1
@@ -7,8 +7,7 @@ Write-Output "--- Bundle install"
 bundle config --local path vendor/bundle
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
-gem update -N
-gem install bundler
+gem install rake
 
 bundle install --retry=3
 If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/.expeditor/run_windows_tests.ps1
+++ b/.expeditor/run_windows_tests.ps1
@@ -4,12 +4,10 @@ $ErrorActionPreference = "Stop"
 
 Write-Output "--- Bundle install"
 
-bundle config --local path vendor/bundle
+bundle config set --local path vendor/bundle
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
-gem install rake
-
-bundle install --retry=3
+bundle install --jobs=7 --retry=3
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "--- Bundle Execute"


### PR DESCRIPTION
## Description
There was an issue with cached gems in the script that runs verifications tests, this caused test run failure on Ruby 3.1 Windows agent.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
