### PR TITLE
Add CINC to product matrix

### DIFF
--- a/lib/mixlib/install/product_matrix.rb
+++ b/lib/mixlib/install/product_matrix.rb
@@ -47,6 +47,11 @@ PRODUCT_MATRIX = Mixlib::Install::ProductMatrix.new do
     package_name "chef"
   end
 
+  product "cinc" do
+    product_name "Cinc Client"
+    package_name "cinc"
+  end
+
   product "chef-foundation" do
     product_name "Chef Foundation"
     package_name "chef-foundation"

--- a/spec/unit/mixlib/install/product_spec.rb
+++ b/spec/unit/mixlib/install/product_spec.rb
@@ -137,6 +137,7 @@ context "PRODUCT_MATRIX" do
     angrychef
     automate
     chef
+    cinc
     chef-foundation
     chef-universal
     chef-backend


### PR DESCRIPTION
The chef_client_updater needs the cinc product adding to mixlib-install so that it can support cinc-client upgrades.

## Description
I've been trying to get a cinc-client upgrade from 15.6.10 to work to 18.2.7, but this fails with the latest mixlib-install gem (3.12.27) and the latest sources of https://github.com/chef-cookbooks/chef_client_updater (3.12.1).

An additional change is required in https://github.com/chef-cookbooks/chef_client_updater/blob/main/providers/default.rb to make the upgrade process work as below. See https://github.com/chef-cookbooks/chef_client_updater/pull/252

```
def legacy_conf_dir_name
  if defined?(::ChefUtils::Dist::Org::LEGACY_CONF_DIR)
    ::ChefUtils::Dist::Org::LEGACY_CONF_DIR
  elsif new_resource.product_name == 'cinc'
    'cinc-project'
  else
    'opscode'
  end
end
```

For me, this was enough to get the upgrade working.

## Related Issue
https://github.com/chef-cookbooks/chef_client_updater/issues/228
https://github.com/chef/mixlib-install/issues/339
https://github.com/chef-cookbooks/chef_client_updater/issues/249

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
