### PR TITLE
Add support for Amazon Linux 2023 in install.sh

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -68,18 +68,22 @@ elif test -f "/etc/system-release"; then
     . /etc/os-release
     platform_version=$VERSION_ID
 
-    if test "$platform_version" = "2022"; then
-      platform="amazon"
-      platform_version="2022"
-    elif test "$platform_version" = "2"; then
-      platform="el"
-      platform_version="7"
-    else
-      platform="el"
+    case $platform_version in
+      "2022"|"2023")
+        platform="amazon"
+        platform_version=$platform_version
+        ;;
+      "2")
+        platform="el"
+        platform_version="7"
+        ;;
+      "*")
+        platform="el"
 
-      # VERSION_ID will match YYYY.MM for Amazon Linux AMIs
-      platform_version="6"
-    fi
+        # VERSION_ID will match YYYY.MM for Amazon Linux AMIs
+        platform_version="6"
+        ;;
+    esac
   esac
 
 # Apple macOS


### PR DESCRIPTION
Adds support for AL2023 detection in `install.sh`.

## Description
Currently AL2023 isn't detected and falls back to EL6, which doesn't have recent packages usually.

## Related Issue
https://gitlab.com/cinc-project/upstream/mixlib-install/-/issues/5

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
