### PR TITLE
fix amazon linux1 platform and version detection

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh
@@ -77,7 +77,7 @@ elif test -f "/etc/system-release"; then
         platform="el"
         platform_version="7"
         ;;
-      "*")
+      *)
         platform="el"
 
         # VERSION_ID will match YYYY.MM for Amazon Linux AMIs


### PR DESCRIPTION
The case statement for platform detections seems to have a string for wildcard (*) which fails to fetch metadata for amazon linux 1 during chef install. Fixing this.

<!--- Provide a short summary of your changes in the Title above -->

## Description
We encountered many instances running Amazon Linux 1 throwing the following output, it looks like the platform and version are not correctly updated because of the wildcard being a string in the case statement.
amazon linux ami 2018.03 x86_64
Getting information for chef stable  for amazon linux ami...
downloading https://omnitruck.chef.io/stable/chef/metadata?v=&p=amazon linux ami&pv=2018.03&m=x86_64
  to file /tmp/install.sh.27900/metadata.txt
trying wget...
trying curl...
cat: /tmp/install.sh.27900/metadata.txt: No such file or directory

grep: /tmp/install.sh.27900/metadata.txt: No such file or directory
downloaded metadata file is corrupted or an uncaught error was encountered in downloading the file...
Version:

Please file a Bug Report at https://github.com/chef/omnitruck/issues/new
Alternatively, feel free to open a Support Ticket at https://www.chef.io/support/tickets
More Chef support resources can be found at https://www.chef.io/support

Please include as many details about the problem as possible i.e., how to reproduce
the problem (if possible), type of the Operating System and its version, etc.,
and any other relevant details that might help us with troubleshooting.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/chef/mixlib-install/issues/393

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
