### PR TITLE
fixing api call to the amazon2 error

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,14 +11,6 @@ expeditor:
 
 steps:
 
-- label: run-specs-ruby-2.7
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.7
-
 - label: run-specs-ruby-3.0
   command:
     - .expeditor/run_linux_tests.sh rake

--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -164,14 +164,14 @@ module Mixlib
     # Automatically set the platform options
     #
     def detect_platform
-      options.set_platform_info(self.class.detect_platform)
+      options.set_platform_info(self.class.detect_platform(options))
       self
     end
 
     #
     # Returns a Hash containing the platform info options
     #
-    def self.detect_platform
+    def self.detect_platform(options)
       product = options.product_name
       version = options.product_version
 
@@ -205,14 +205,14 @@ module Mixlib
       if product == "chef-server" && version >= "15.10.12" && platform == "el" && platform_version == "7"
         platform = "amazon"
         platform_version = "2"
-      else
+      end
+
       {
-        platform: platform_info[0],
-        platform_version: platform_info[1],
-        architecture: platform_info[2],
+        platform: platform,
+        platform_version: platform_version,
+        architecture: architecture
       }
     end
-  end
 
     #
     # Returns the platform_detection.sh script

--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -172,6 +172,10 @@ module Mixlib
     # Returns a Hash containing the platform info options
     #
     def self.detect_platform
+      product = options.product_name
+      version = options.product_version
+
+
       output = if Gem.win_platform?
                  # For Windows we write the detect platform script and execute the
                  # powershell.exe program with Mixlib::ShellOut
@@ -191,13 +195,24 @@ module Mixlib
                end
 
       platform_info = output.stdout.split
+      platform = platform_info[0]
+      platform_version = platform_info[1]
+      architecture = platform_info[2]
 
+      # since we forked away from rhel 7 as a builder and used amazon 2 as a builder for chef-server, this is a fix to address the api call on omnitruck and other download services
+      # will need to fix this before the next chef-server release
+
+      if product == "chef-server" && version >= "15.10.12" && platform == "el" && platform_version == "7"
+        platform = "amazon"
+        platform_version = "2"
+      else
       {
         platform: platform_info[0],
         platform_version: platform_info[1],
         architecture: platform_info[2],
       }
     end
+  end
 
     #
     # Returns the platform_detection.sh script

--- a/spec/unit/mixlib/install_spec.rb
+++ b/spec/unit/mixlib/install_spec.rb
@@ -196,7 +196,14 @@ context "Mixlib::Install" do
 
   context "self.detect_platform" do
     let(:product_name) { "chef" }
-    let(:platform_info) { Mixlib::Install.detect_platform }
+    let(:options) do
+      opts = Mixlib::Install::Options.new(
+        product_name: product_name,
+        product_version: '0.0.1',
+        channel: :stable
+      )
+    end
+    let(:platform_info) { Mixlib::Install.detect_platform(options) }
 
     it "should return platform info" do
       expect(platform_info.size).to eq 3


### PR DESCRIPTION
this is addressing where we removed rhel-7 as a builder which produced files like chef-server-ver-el7.rpm

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

There is an issue where we cant get the proper data back from package router, omnitruck, or mixlib install.

When requesting to install the latest version:

```
Mixlib::Install.new(product_name: "chef-server", product_version: '15.10.12', channel: :stable, platform: "amazon", platform_version: "2", architecture: "x86_64").download_artifact
```
It will 404 and or error, as the platform detection script is invalid. (https://github.com/chef/mixlib-install/blob/main/lib/mixlib/install/generator/bourne/scripts/platform_detection.sh#L64-L87)

We cant just update the platform_detection script, as that will break legacy downloads of older versions, thus we have to handle this in ruby to account for the detection, then re-write that in the call. 

## testing this change

To test this change these are the steps i followed. 

1. Pull down my branch
2. update the version in mixlib-install/lib/mixlib/install/version.rb file 
3. build the gem with `gem build mixlib-install.gemspec`
4. once built, install the gem: `gem install --local gems/mixlib-install-3.12.31.gem`
5. gems required:
    ``` 
    gem 'thor'
    gem 'mixlib-versioning'
    gem 'mixlib-shellout'
    ```
6. interface directly with the api:
7. `Mixlib::Install.new(product_name: "chef-server", product_version: '15.10.12', channel: :stable, platform: "amazon", platform_version: "2", architecture: "x86_64").download_artifact` should grab a file: `chef-server-core-15.10.12-1.amazon2.x86_64.rpm`
8. try an older version:
9. `puts Mixlib::Install.new(product_name: "chef-server", product_version: '15.9.38', channel: :stable, platform: "amazon", platform_version: "2", architecture: "x86_64").download_artifact`

I used a docker image to test these locally, to keep my env clean. 

### Docker file:
```
FROM ruby:3.3

# throw errors if Gemfile has been modified since Gemfile.lock
RUN bundle config --global frozen 1

WORKDIR /usr/src/app

COPY . .

RUN bundle install

RUN gem install --local gems/mixlib-install-3.12.31.gem

```
docker build . -t rubygem-local-test-01
docker run -it --privileged --volume $(pwd):/home rubygem-local-test-01 /bin/bash

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
