### PR TITLE
Download install sh from new download api

### DIFF
--- a/lib/mixlib/install/generator.rb
+++ b/lib/mixlib/install/generator.rb
@@ -22,11 +22,10 @@ module Mixlib
   class Install
     class Generator
       def self.install_command(options)
-        if options.for_ps1?
-          PowerShell.new(options).install_command
-        else
-          Bourne.new(options).install_command
-        end
+        klass = options.for_ps1? ? PowerShell : Bourne
+        meth = options.options[:new_omnibus_download_url] ? :install_sh_from_upstream : :install_command
+
+        klass.new(options).send(meth)
       end
     end
   end

--- a/lib/mixlib/install/generator/base.rb
+++ b/lib/mixlib/install/generator/base.rb
@@ -19,6 +19,7 @@ require "erb" unless defined?(Erb)
 require "ostruct" unless defined?(OpenStruct)
 require_relative "../util"
 require_relative "../dist"
+require "net/http" unless defined?(Net::HTTP)
 
 module Mixlib
   class Install
@@ -67,6 +68,17 @@ module Mixlib
 
         def get_script(name, context = {})
           self.class.get_script(name, context)
+        end
+
+        def install_sh_from_upstream
+          uri = URI.parse(options.options[:new_omnibus_download_url])
+          response = Net::HTTP.get_response(uri)
+
+          if response.code == "200"
+            response.body
+          else
+            raise StandardError, "unable to fetch the install.sh"
+          end
         end
       end
     end

--- a/lib/mixlib/install/script_generator.rb
+++ b/lib/mixlib/install/script_generator.rb
@@ -21,6 +21,7 @@ require_relative "util"
 require_relative "generator/powershell"
 require_relative "dist"
 require "cgi"
+require "net/http" unless defined?(Net::HTTP)
 
 module Mixlib
   class Install
@@ -99,6 +100,17 @@ module Mixlib
                  install_command_vars_for_bourne
                end
         shell_code_from_file(vars)
+      end
+
+      def install_command_from_omnitruck(url)
+        uri = URI.parse(url)
+        response = Net::HTTP.get_response(uri)
+
+        if response.code == "200"
+          response.body
+        else
+          raise StandardError, "unable to fetch the install.sh"
+        end
       end
 
       private


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The install.sh and install.ps1 files are moved to the new download API and maintained there. If the options has the new key, instead of building the file, download it from the new download api.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
