### PR TITLE
CHEF-29613 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -428,3 +428,6 @@ VCR is a tool that helps cache and replay http responses. When these responses c
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+
+# Copyright
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Thom May (<thom@chef.io>)
 # Author:: Patrick Wright (<patrick@chef.io>)
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/artifact_info.rb
+++ b/lib/mixlib/install/artifact_info.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Patrick Wright (<patrick@chef.io>)
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/backend.rb
+++ b/lib/mixlib/install/backend.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Patrick Wright (<patrick@chef.io>)
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/backend/base.rb
+++ b/lib/mixlib/install/backend/base.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Patrick Wright (<patrick@chef.io>)
-# Copyright:: Copyright (c) 2016-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/backend/package_router.rb
+++ b/lib/mixlib/install/backend/package_router.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Patrick Wright (<patrick@chef.io>)
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/generator.rb
+++ b/lib/mixlib/install/generator.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/generator/base.rb
+++ b/lib/mixlib/install/generator/base.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/generator/bourne.rb
+++ b/lib/mixlib/install/generator/bourne.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/generator/bourne/scripts/helpers.sh.erb
+++ b/lib/mixlib/install/generator/bourne/scripts/helpers.sh.erb
@@ -4,7 +4,7 @@
 # - must run on /bin/sh on solaris 9
 # - must run on /bin/sh on AIX 6.x
 #
-# Copyright:: Copyright (c) 2010-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/generator/powershell.rb
+++ b/lib/mixlib/install/generator/powershell.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/options.rb
+++ b/lib/mixlib/install/options.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Patrick Wright (<patrick@chef.io>)
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/product.rb
+++ b/lib/mixlib/install/product.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/script_generator.rb
+++ b/lib/mixlib/install/script_generator.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Thom May (<thom@chef.io>)
 # Author:: Patrick Wright (<patrick@chef.io>)
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/mixlib/install/util.rb
+++ b/lib/mixlib/install/util.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Thom May (<thom@chef.io>)
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/functional/mixlib/install/cli_spec.rb
+++ b/spec/functional/mixlib/install/cli_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2016-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/mixlib/install/backend/package_router_spec.rb
+++ b/spec/unit/mixlib/install/backend/package_router_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Patrick Wright (<patrick@chef.io>)
-# Copyright:: Copyright (c) 2016 Chef, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/mixlib/install/backend_spec.rb
+++ b/spec/unit/mixlib/install/backend_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Patrick Wright (<patrick@chef.io>)
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/mixlib/install/generator_spec.rb
+++ b/spec/unit/mixlib/install/generator_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/mixlib/install/options_spec.rb
+++ b/spec/unit/mixlib/install/options_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Patrick Wright (<patrick@chef.io>)
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/mixlib/install/product_spec.rb
+++ b/spec/unit/mixlib/install/product_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/mixlib/install/script_generator_spec.rb
+++ b/spec/unit/mixlib/install/script_generator_spec.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Thom May (<thom@chef.io>)
 # Author:: Patrick Wright (<patrick@chef.io>)
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/mixlib/install/util_spec.rb
+++ b/spec/unit/mixlib/install/util_spec.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Thom May (<thom@chef.io>)
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/mixlib/install_spec.rb
+++ b/spec/unit/mixlib/install_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015-2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2015-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2015-2025 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme
- `spec/unit/mixlib/install/backend/package_router_spec.rb:3` - Unmatched copyright format (review needed)
- `.github/copilot-instructions.md:60` - Unmatched copyright format (review needed)

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
