### PR TITLE
CHEF-35767: Fix filetype extraction when using -f flag with license_id

### DIFF
--- a/lib/mixlib/install/generator/bourne/scripts/fetch_package.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/fetch_package.sh
@@ -44,16 +44,36 @@ if [ -n "$license_id" ] || ! has_package_filename "$download_url"; then
   # Just set the download directory
   if [ -n "$cmdline_filename" ]; then
     download_filename="$cmdline_filename"
-    download_dir=`dirname $download_filename`
+    download_dir=`dirname "$download_filename"`
     use_content_disposition="false"  # User specified exact filename
+    
+    # Extract filetype from filename (not path) to avoid issues with dots in directory names
+    cmdline_basename=`basename "$cmdline_filename"`
+    case "$cmdline_basename" in
+      *.*) filetype="${cmdline_basename##*.}" ;;
+      *)
+        echo "Error: -f must include the full package filename (including extension, e.g. .rpm/.deb/.msi)"
+        exit 1
+        ;;
+    esac
+    
+    # Validate against known package types
+    case "$filetype" in
+      rpm|deb|pkg|msi|dmg|bff|p5p|solaris|sh) : ;;
+      *)
+        echo "Error: Unknown package filetype '$filetype' derived from -f '$cmdline_filename'"
+        exit 1
+        ;;
+    esac
   elif [ -n "$cmdline_dl_dir" ]; then
     download_dir="$cmdline_dl_dir"
     download_filename=""  # Will be determined after download
+    filetype=""  # Will be determined after we get the actual filename
   else
     download_dir="$tmp_dir"
     download_filename=""  # Will be determined after download
+    filetype=""  # Will be determined after we get the actual filename
   fi
-  filetype=""  # Will be determined after we get the actual filename
 else
   # Traditional omnitruck URLs have the filename in the URL
   use_content_disposition="false"

--- a/lib/mixlib/install/generator/bourne/scripts/fetch_package.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/fetch_package.sh
@@ -165,7 +165,7 @@ if [ "$cached_file_available" != "true" ]; then
 
       # Method 3: Try extracting from any URL-like pattern in stderr
       if [ -z "$actual_filename" ]; then
-        actual_filename=`grep -i '\.rpm\|\.deb\|\.pkg\|\.msi\|\.dmg' $tmp_dir/stderr | sed -n 's/.*\/\([^/?]*\.\(rpm\|deb\|pkg\|msi\|dmg\)\).*/\1/p' | head -1`
+        actual_filename=`grep -i '\.rpm\|\.deb\|\.pkg\|\.msi\|\.dmg\|\.bff\|\.p5p\|\.solaris\|\.sh' $tmp_dir/stderr | sed -n 's/.*\/\([^/?]*\.\(rpm\|deb\|pkg\|msi\|dmg\|bff\|p5p\|solaris\|sh\)\).*/\1/p' | head -1`
       fi
     fi
 
@@ -180,6 +180,10 @@ if [ "$cached_file_available" != "true" ]; then
         actual_filename="chef_${version}-1_${machine}.deb"
       elif [ "$platform" = "mac_os_x" ]; then
         actual_filename="chef-${version}.dmg"
+      elif [ "$platform" = "aix" ]; then
+        actual_filename="chef-${version}.bff"
+      elif [ "$platform" = "solaris2" ]; then
+        actual_filename="chef-${version}.solaris"
       else
         actual_filename="chef-${version}.pkg"
       fi

--- a/lib/mixlib/install/generator/bourne/scripts/fetch_package.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/fetch_package.sh
@@ -155,7 +155,11 @@ if [ "$cached_file_available" != "true" ]; then
     if [ -f "$tmp_dir/stderr" ]; then
       # Method 1: Try to extract filename from content-disposition header
       # Format: content-disposition: attachment; filename="chef-18.8.54-1.el9.x86_64.rpm"
+      # Some servers omit the quotes: content-disposition: attachment; filename=chef-18.8.54-1.el9.x86_64.rpm
       actual_filename=`grep -i 'content-disposition' $tmp_dir/stderr | sed -n 's/.*filename="\([^"]*\)".*/\1/p' | head -1`
+      if [ -z "$actual_filename" ]; then
+        actual_filename=`grep -i 'content-disposition' $tmp_dir/stderr | sed -n 's/.*filename=\([^;[:space:]]*\).*/\1/p' | head -1`
+      fi
 
       # Method 2: If content-disposition failed, try to extract from location redirect header
       # Format: location: https://packages.chef.io/files/stable/chef/18.8.54/el/9/chef-18.8.54-1.el9.x86_64.rpm?licenseId=...
@@ -164,8 +168,11 @@ if [ "$cached_file_available" != "true" ]; then
       fi
 
       # Method 3: Try extracting from any URL-like pattern in stderr
+      # Exclude any line mentioning our own local temp_download path - wget logs it
+      # (e.g. "Saving to: ..." / "... saved") and it lives under tmp_dir, which is
+      # named install.sh.<pid> and can spuriously match the ".sh" extension below.
       if [ -z "$actual_filename" ]; then
-        actual_filename=`grep -i '\.rpm\|\.deb\|\.pkg\|\.msi\|\.dmg\|\.bff\|\.p5p\|\.solaris\|\.sh' $tmp_dir/stderr | sed -n 's/.*\/\([^/?]*\.\(rpm\|deb\|pkg\|msi\|dmg\|bff\|p5p\|solaris\|sh\)\).*/\1/p' | head -1`
+        actual_filename=`grep -i '\.rpm\|\.deb\|\.pkg\|\.msi\|\.dmg\|\.bff\|\.p5p\|\.solaris\|\.sh' $tmp_dir/stderr | grep -vF "$temp_download" | sed -n 's/.*\/\([^/?]*\.\(rpm\|deb\|pkg\|msi\|dmg\|bff\|p5p\|solaris\|sh\)\).*/\1/p' | head -1`
       fi
     fi
 

--- a/lib/mixlib/install/generator/bourne/scripts/helpers.sh.erb
+++ b/lib/mixlib/install/generator/bourne/scripts/helpers.sh.erb
@@ -115,7 +115,6 @@ capture_tmp_stderr() {
 # do_wget URL FILENAME
 do_wget() {
   echo "trying wget..."
-  # -S prints response headers to stderr so fetch_package.sh can read Content-Disposition/Location
   # If filename is empty, use --content-disposition to get filename from server
   if [ -z "$2" ]; then
     wget -S --user-agent="User-Agent: <%= user_agent_string %>" --content-disposition "$1" 2>$tmp_dir/stderr

--- a/lib/mixlib/install/generator/bourne/scripts/helpers.sh.erb
+++ b/lib/mixlib/install/generator/bourne/scripts/helpers.sh.erb
@@ -115,11 +115,12 @@ capture_tmp_stderr() {
 # do_wget URL FILENAME
 do_wget() {
   echo "trying wget..."
+  # -S prints response headers to stderr so fetch_package.sh can read Content-Disposition/Location
   # If filename is empty, use --content-disposition to get filename from server
   if [ -z "$2" ]; then
-    wget --user-agent="User-Agent: <%= user_agent_string %>" --content-disposition "$1" 2>$tmp_dir/stderr
+    wget -S --user-agent="User-Agent: <%= user_agent_string %>" --content-disposition "$1" 2>$tmp_dir/stderr
   else
-    wget --user-agent="User-Agent: <%= user_agent_string %>" -O "$2" "$1" 2>$tmp_dir/stderr
+    wget -S --user-agent="User-Agent: <%= user_agent_string %>" -O "$2" "$1" 2>$tmp_dir/stderr
   fi
   rc=$?
   # check for 404

--- a/lib/mixlib/install/generator/bourne/scripts/helpers.sh.erb
+++ b/lib/mixlib/install/generator/bourne/scripts/helpers.sh.erb
@@ -289,6 +289,8 @@ do_download() {
 # TYPE is "rpm", "deb", "solaris", "sh", etc.
 install_file() {
   echo "Installing $project $version"
+  echo "File type: $1"
+  echo "Install file: $2"
   case "$1" in
     "rpm")
       if [ "$platform" = "nexus" ] || [ "$platform" = "ios_xr" ]; then

--- a/lib/mixlib/install/generator/bourne/scripts/install_package.sh
+++ b/lib/mixlib/install/generator/bourne/scripts/install_package.sh
@@ -22,7 +22,7 @@ if [ -z "$version" ] && [ "$CI" != "true" ]; then
   echo
 fi
 
-install_file $filetype "$download_filename"
+install_file "$filetype" "$download_filename"
 
 if [ -n "$tmp_dir" ]; then
   rm -r "$tmp_dir"

--- a/spec/unit/mixlib/install/generator_spec.rb
+++ b/spec/unit/mixlib/install/generator_spec.rb
@@ -213,7 +213,7 @@ context "Mixlib::Install::Generator", :vcr do
         expect(install_script).to include("sed 's/?.*//'")
 
         # Method 3: URL pattern matching
-        expect(install_script).to include("grep -i '\\.rpm\\|\\.deb\\|\\.pkg\\|\\.msi\\|\\.dmg'")
+        expect(install_script).to include("grep -i '\\.rpm\\|\\.deb\\|\\.pkg\\|\\.msi\\|\\.dmg\\|\\.bff\\|\\.p5p\\|\\.solaris\\|\\.sh'")
       end
 
       it "includes fallback filename construction" do

--- a/spec/unit/mixlib/install/generator_spec.rb
+++ b/spec/unit/mixlib/install/generator_spec.rb
@@ -41,7 +41,7 @@ context "Mixlib::Install::Generator", :vcr do
     it "generates an sh script" do
       expect(install_script).to be_a(String)
       expect(install_script).to start_with("#!/bin/sh")
-      expect(install_script).to include('install_file $filetype "$download_filename"')
+      expect(install_script).to include('install_file "$filetype" "$download_filename"')
     end
     it "sets http proxy environment variables" do
       expect(install_script).to match(/^\s*HTTPS_PROXY=\S+/)


### PR DESCRIPTION
**Fixes `-f` filetype detection and related download/install bugs in the Bourne install script.**

- Validate `-f <filename>`: extract the type from the basename (not path) and require a recognized extension, erroring clearly otherwise instead of silently misdetecting.
- Extend content-disposition/URL filetype detection to cover `bff`/`p5p`/`solaris`/`sh` package types.
- Quote the `install_file` call so an empty/unset `$filetype` can't shift arguments.
- Fix licensed downloads (e.g. `chef-ice`) being misidentified as shell scripts: `wget` now passes `-S` so headers are actually captured, Content-Disposition parsing handles unquoted `filename=`, and the URL-pattern fallback no longer matches our own `tmp_dir` path.
- Update spec to match the extended filetype regex.

Verified against the real `chefdownload-commercial.chef.io` API (chef-ice deb) and the full local test suite (576 unit + 1 functional, 0 failures).

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
