### PR TITLE
remove free- prefix from trial api endpoint url resolution.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -130,7 +130,7 @@ All Ruby files should include the Apache 2.0 license header:
    - PowerShell (install.ps1) generator with JSON API response parsing
    - Supports proxy configuration, download_url_override, and license_id
    - **Commercial/Trial API Support**: When license_id is provided, uses specialized download endpoints
-     - Trial API: `https://chefdownload-trial.chef.io` (for license IDs starting with `free-` or `trial-`)
+     - Trial API: `https://chefdownload-trial.chef.io` (for license IDs starting with `trial-`)
      - Commercial API: `https://chefdownload-commercial.chef.io` (for other license IDs)
      - Returns JSON responses instead of text format
      - Uses Content-Disposition headers for filename extraction
@@ -287,7 +287,7 @@ The library includes sophisticated platform version compatibility logic:
 - Generated via `lib/mixlib/install/generator/bourne.rb`
 - **API Endpoint Selection**: Uses `base_api_url` parameter to determine endpoint:
   - If `base_api_url` is empty and `license_id` is provided:
-    - Trial API: `https://chefdownload-trial.chef.io` (for `free-*` or `trial-*` prefixes)
+    - Trial API: `https://chefdownload-trial.chef.io` (for `trial-*` prefixes)
     - Commercial API: `https://chefdownload-commercial.chef.io` (for other license IDs)
   - If `base_api_url` is empty and no `license_id`: Omnitruck API `https://omnitruck.chef.io`
   - If `base_api_url` is set: Uses the provided URL (allows override)
@@ -313,8 +313,8 @@ The library includes sophisticated platform version compatibility logic:
 - Generated via `lib/mixlib/install/generator/powershell.rb`
 - **API Endpoint Selection**: Uses `base_server_uri` parameter to determine endpoint:
   - If `base_server_uri` is empty and `license_id` is provided:
-    - Trial API: `https://chefdownload-trial.chef.io` (for `free-*` or `trial-*` prefixes)
-    - Commercial API: `https://chefdownload-commercial.chef.io` (for other license IDs)
+    - Trial API: `https://chefdownload-trial.chef.io` (for `trial-*` prefixes)
+    - Commercial API: `https://chefdownload-commercial.chef.io` (for other license IDs, including `free-*`)
   - If `base_server_uri` is empty and no `license_id`: Omnitruck API `https://omnitruck.chef.io`
   - If `base_server_uri` is set: Uses the provided URL (allows override)
 - **JSON API Response**: When `license_id` is provided:
@@ -330,7 +330,7 @@ The library includes sophisticated platform version compatibility logic:
 - `download_url_override`: Direct URL instead of API lookup
 - `checksum`: SHA256 for verification
 - `install_strategy`: "once" to skip if already installed
-- `license_id`: License ID for commercial/trial API access (format: `free-*`, `trial-*`, or standard license ID)
+- `license_id`: License ID for commercial/trial API access (format: `trial-*` for trial API, or any other value including `free-*` for commercial API)
 - `base_api_url` (shell): Override API endpoint (optional, auto-detected from license_id if not provided)
 - `base_server_uri` (PowerShell): Override API endpoint (optional, auto-detected from license_id if not provided)
 - `-i <pm>` / `$package_manager`: Explicit package manager override (e.g. `msi`, `zip`). Omit to let the server derive it from platform. Appends `&pm=<value>` to the metadata URL when set.
@@ -382,12 +382,12 @@ Mixlib::Install supports Chef's commercial and trial licensing APIs, which provi
 
 ### API Endpoints
 - **Trial API**: `https://chefdownload-trial.chef.io`
-  - Used when `license_id` starts with `free-` or `trial-`
+  - Used when `license_id` starts with `trial-`
   - Returns JSON responses with download URLs
   - **Restrictions**: Only `stable` channel and `latest` version supported
   - Defaults are automatically enforced with warnings
 - **Commercial API**: `https://chefdownload-commercial.chef.io`
-  - Used for standard license IDs
+  - Used for all other license IDs (including `free-` prefix)
   - Returns JSON responses with download URLs
   - No restrictions on channels or versions
 - **Traditional Omnitruck**: `https://omnitruck.chef.io`
@@ -421,18 +421,18 @@ The backend (`lib/mixlib/install/backend/package_router.rb`) includes enhanced e
 require 'mixlib/install/dist'
 
 # Check if license_id indicates trial API usage
-Mixlib::Install::Dist.trial_license?('free-trial-123')      # => true
+Mixlib::Install::Dist.trial_license?('free-trial-123')      # => false
 Mixlib::Install::Dist.trial_license?('trial-abc-456')       # => true
 Mixlib::Install::Dist.trial_license?('commercial-xyz')      # => false
 
 # Check if license_id indicates commercial API usage
 Mixlib::Install::Dist.commercial_license?('commercial-xyz') # => true
-Mixlib::Install::Dist.commercial_license?('free-trial-123') # => false
+Mixlib::Install::Dist.commercial_license?('free-trial-123') # => true
 ```
 
 **Trial License Detection Logic**:
-- Returns `true` if license_id starts with `free-` or `trial-`
-- Returns `false` for nil, empty string, or other prefixes
+- Returns `true` if license_id starts with `trial-`
+- Returns `false` for nil, empty string, or other prefixes (including `free-`)
 
 **Commercial License Detection Logic**:
 - Returns `true` if license_id is present and NOT a trial license
@@ -460,8 +460,8 @@ Commercial and trial APIs return endpoint URLs that use HTTP Content-Disposition
 
 ### Testing Commercial/Trial API Features
 When adding or modifying commercial/trial API functionality:
-1. Test with `license_id` starting with `free-` (trial API)
 1. Test with `license_id` starting with `trial-` (trial API)
+1. Test with `license_id` starting with `free-` (commercial API)
 1. Test with standard license ID format (commercial API)
 1. Verify JSON parsing in both Bourne shell (sed) and PowerShell (ConvertFrom-Json)
 1. Test filename extraction with various response header formats
@@ -521,14 +521,14 @@ end
 ```ruby
 it "defaults to stable channel when current channel is specified" do
   expect do
-    mi = Mixlib::Install.new(product_name: "chef", channel: :current, license_id: "free-trial-abc-123")
+    mi = Mixlib::Install.new(product_name: "chef", channel: :current, license_id: "trial-abc-123")
     expect(mi.options.channel).to eq :stable
   end.to output(/WARNING: Trial API only supports 'stable' channel/).to_stderr
 end
 
 it "defaults to latest version when specific version is specified" do
   expect do
-    mi = Mixlib::Install.new(product_name: "chef", product_version: "15.0.0", license_id: "free-trial-abc-123")
+    mi = Mixlib::Install.new(product_name: "chef", product_version: "15.0.0", license_id: "trial-abc-123")
     expect(mi.options.product_version).to eq :latest
   end.to output(/WARNING: Trial API only supports 'latest' version/).to_stderr
 end
@@ -613,11 +613,11 @@ options = {
   platform: 'ubuntu',
   platform_version: '20.04',
   architecture: 'x86_64',
-  license_id: 'free-trial-abc-123'
+  license_id: 'trial-abc-123'
 }
 
 artifact = Mixlib::Install.new(options).artifact_info
-# URL: https://chefdownload-trial.chef.io/stable/chef-ice/download?p=ubuntu&pv=20.04&m=x86_64&v=19.1.151&license_id=free-trial-abc-123
+# URL: https://chefdownload-trial.chef.io/stable/chef-ice/download?p=ubuntu&pv=20.04&m=x86_64&v=19.1.151&license_id=trial-abc-123
 ```
 
 ## Common Pitfalls to Avoid
@@ -740,8 +740,8 @@ When making changes:
 
 | License Type | ID Format | API Endpoint | Channel | Version | Auto-Defaults |
 |-------------|-----------|--------------|---------|---------|---------------|
-| **Trial** | `free-*` or `trial-*` | https://chefdownload-trial.chef.io | stable only | latest only | Yes (with warnings) |
-| **Commercial** | Any other format | https://chefdownload-commercial.chef.io | Any | Any | No |
+| **Trial** | `trial-*` | https://chefdownload-trial.chef.io | stable only | latest only | Yes (with warnings) |
+| **Commercial** | Any other format (including `free-*`) | https://chefdownload-commercial.chef.io | Any | Any | No |
 | **Open Source** | None | https://omnitruck.chef.io | Any | Any | No |
 
 ---

--- a/ADR/adr0001.md
+++ b/ADR/adr0001.md
@@ -25,8 +25,8 @@ The challenge was to implement this authentication mechanism while:
 
 We implemented a dual-API system with license-based authentication through a `license_id` parameter. The solution introduces two new API endpoints alongside the existing Omnitruck API:
 
-1. **Trial API** (`https://chefdownload-trial.chef.io`): For license IDs starting with `free-` or `trial-`
-2. **Commercial API** (`https://chefdownload-commercial.chef.io`): For standard license IDs
+1. **Trial API** (`https://chefdownload-trial.chef.io`): For license IDs starting with `trial-`
+2. **Commercial API** (`https://chefdownload-commercial.chef.io`): For standard license IDs (including `free-` prefix)
 3. **Omnitruck API** (`https://omnitruck.chef.io`): Continues to work when no license_id is provided (backward compatible)
 
 The implementation adds a new `license_id` option throughout the mixlib-install stack:
@@ -38,7 +38,7 @@ The implementation adds a new `license_id` option throughout the mixlib-install 
 **API Routing Logic**:
 
 ```ruby
-if license_id.start_with?("free-", "trial-")
+if license_id.start_with?("trial-")
   endpoint = "https://chefdownload-trial.chef.io"
 elsif license_id.present?
   endpoint = "https://chefdownload-commercial.chef.io"
@@ -122,7 +122,7 @@ end
 
 def use_trial_api?
   !options.license_id.nil? && !options.license_id.to_s.empty? &&
-    options.license_id.start_with?("free-", "trial-")
+    options.license_id.start_with?("trial-")
 end
 
 def use_commercial_api?
@@ -208,9 +208,9 @@ end
 
 # Use commercial API if license_id is provided, otherwise use omnitruck
 if test "x$license_id" != "x"; then
-  # Check if license_id starts with 'free-' or 'trial-' for trial API
+  # Route to trial API only for trial- prefix; all others use commercial API
   case "$license_id" in
-    free-*|trial-*)
+    trial-*)
       base_api_url="https://chefdownload-trial.chef.io"
       ;;
     *)
@@ -291,7 +291,7 @@ function Get-ProjectMetadata {
 
   # Use commercial API if license_id is provided
   if ($license_id) {
-    if ($license_id -match '^(free-|trial-)') {
+    if ($license_id -match '^trial-') {
       $base_server_uri = 'https://chefdownload-trial.chef.io'
     } else {
       $base_server_uri = 'https://chefdownload-commercial.chef.io'
@@ -350,13 +350,13 @@ sequenceDiagram
     participant Trial API
     participant Omnitruck API
 
-    User->>Mixlib Install: new(license_id: "free-abc-123")
+    User->>Mixlib Install: new(license_id: "trial-abc-123")
     Mixlib Install->>Package Router: detect API endpoint
 
-    alt license_id starts with "free-" or "trial-"
+    alt license_id starts with "trial-"
         Package Router->>Trial API: GET /stable/chef/metadata?license_id=...
         Trial API-->>Package Router: JSON response
-    else license_id provided (commercial)
+    else license_id provided (commercial, including free- prefix)
         Package Router->>Commercial API: GET /stable/chef/metadata?license_id=...
         Commercial API-->>Package Router: JSON response
     else no license_id
@@ -399,7 +399,7 @@ sequenceDiagram
    - Direct Ruby API usage
    - CLI tool
 
-6. **Flexible Authentication**: Supports multiple license types through simple prefix-based routing (free-/trial- vs commercial)
+6. **Flexible Authentication**: Supports multiple license types through simple prefix-based routing (`trial-` prefix vs all other license IDs)
 
 7. **Content-Disposition Resilience**: Implements multiple fallback methods for filename extraction, ensuring downloads work even with varying server response formats
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Mixlib::Install supports both commercial and trial API endpoints for licensed Ch
 The trial API is designed for evaluation purposes and has the following restrictions:
 
 - **Endpoint**: `https://chefdownload-trial.chef.io`
-- **License ID Format**: Must start with `free-` or `trial-`
+- **License ID Format**: Must start with `trial-`
 - **Channel Restriction**: Only `stable` channel is supported
 - **Version Restriction**: Only `latest` version is supported
 
@@ -336,7 +336,7 @@ options = {
   product_name: 'chef',
   channel: :current,          # Will be changed to :stable with warning
   product_version: '18.5.0',  # Will be changed to :latest with warning
-  license_id: 'free-trial-abc-123'
+  license_id: 'trial-abc-123'
 }
 
 mi = Mixlib::Install.new(options)
@@ -352,7 +352,7 @@ mi.options.product_version # => :latest
 The commercial API provides full access to all channels and versions:
 
 - **Endpoint**: `https://chefdownload-commercial.chef.io`
-- **License ID Format**: Any valid commercial license ID (not starting with `free-` or `trial-`)
+- **License ID Format**: Any valid commercial license ID (not starting with `trial-`)
 - **Channel Restriction**: None - all channels supported (`stable`, `current`, `unstable`)
 - **Version Restriction**: None - all versions supported
 
@@ -377,7 +377,7 @@ The static methods `Mixlib::Install.install_sh()` and `Mixlib::Install.install_p
 ```ruby
 # Trial API defaults applied to generated script
 script = Mixlib::Install.install_sh(
-  license_id: 'free-trial-xyz',
+  license_id: 'trial-xyz',
   channel: :current,     # Will be changed to :stable with warning
   version: '18.0.0'      # Will be changed to :latest with warning
 )
@@ -392,12 +392,13 @@ You can check if a license ID is for trial or commercial API:
 ```ruby
 require 'mixlib/install/dist'
 
-Mixlib::Install::Dist.trial_license?('free-trial-123')      # => true
+Mixlib::Install::Dist.trial_license?('free-abc-123')        # => false
 Mixlib::Install::Dist.trial_license?('trial-abc-456')       # => true
 Mixlib::Install::Dist.trial_license?('commercial-xyz')      # => false
 
 Mixlib::Install::Dist.commercial_license?('commercial-xyz') # => true
-Mixlib::Install::Dist.commercial_license?('free-trial-123') # => false
+Mixlib::Install::Dist.commercial_license?('free-abc-123') # => true
+Mixlib::Install::Dist.commercial_license?('trial-abc-456') # => false
 ```
 
 ## Development

--- a/lib/mixlib/install.rb
+++ b/lib/mixlib/install.rb
@@ -301,7 +301,7 @@ module Mixlib
     #   url pointing to the omnitruck to be queried by the script.
     # license_id [String]
     #   license ID for commercial or trial API access.
-    #   If license_id starts with 'free-' or 'trial-', trial API defaults are enforced.
+    #   If license_id starts with 'trial-', trial API defaults are enforced.
     #
     def self.install_sh(context = {})
       # Apply trial API defaults if license_id indicates trial
@@ -329,7 +329,7 @@ module Mixlib
     #   url pointing to the omnitruck to be queried by the script.
     # license_id [String]
     #   license ID for commercial or trial API access.
-    #   If license_id starts with 'free-' or 'trial-', trial API defaults are enforced.
+    #   If license_id starts with 'trial-', trial API defaults are enforced.
     #
     def self.install_ps1(context = {})
       # Apply trial API defaults if license_id indicates trial

--- a/lib/mixlib/install/backend/package_router.rb
+++ b/lib/mixlib/install/backend/package_router.rb
@@ -395,7 +395,7 @@ EOF
         end
 
         def use_trial_api?
-          !options.license_id.nil? && !options.license_id.to_s.empty? && options.license_id.start_with?("free-", "trial-")
+          !options.license_id.nil? && !options.license_id.to_s.empty? && options.license_id.start_with?("trial-")
         end
 
         def use_commercial_api?

--- a/lib/mixlib/install/dist.rb
+++ b/lib/mixlib/install/dist.rb
@@ -37,15 +37,15 @@ module Mixlib
 
       # Check if a license_id is for trial API
       # @param license_id [String] the license ID to check
-      # @return [Boolean] true if license_id indicates trial API usage
+      # @return [Boolean] true if license_id starts with 'trial-' (trial API usage)
       def self.trial_license?(license_id)
         !license_id.nil? && !license_id.to_s.empty? &&
-          license_id.start_with?("free-", "trial-")
+          license_id.start_with?("trial-")
       end
 
       # Check if a license_id is for commercial API
       # @param license_id [String] the license ID to check
-      # @return [Boolean] true if license_id indicates commercial API usage
+      # @return [Boolean] true if license_id is non-empty and does not start with 'trial-'
       def self.commercial_license?(license_id)
         !license_id.nil? && !license_id.to_s.empty? &&
           !trial_license?(license_id)

--- a/lib/mixlib/install/generator/bourne/scripts/fetch_metadata.sh.erb
+++ b/lib/mixlib/install/generator/bourne/scripts/fetch_metadata.sh.erb
@@ -39,9 +39,9 @@ if [ -z "$download_url_override" ]; then
   # Use commercial API if license_id is provided, otherwise use omnitruck
   if [ -z "$base_api_url" ]; then
     if [ -n "$license_id" ]; then
-      # Check if license_id starts with 'free-' or 'trial-' for trial API
+      # Check if license_id starts with 'trial-' for trial API
       case "$license_id" in
-        free-*|trial-*)
+        trial-*)
           # Trial API endpoint
           base_api_url="<%= Mixlib::Install::Dist::TRIAL_API_ENDPOINT %>"
           ;;

--- a/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/get_project_metadata.ps1.erb
@@ -75,8 +75,8 @@ function Get-ProjectMetadata {
 
   if ([string]::IsNullOrEmpty($base_server_uri)) {
     if (-not [string]::IsNullOrEmpty($license_id)) {
-      # Check if license_id starts with 'free-' or 'trial-' for trial API
-      if ($license_id -match '^(free-|trial-)') {
+      # Check if license_id starts with 'trial-' for trial API
+      if ($license_id -match '^(trial-)') {
         # Trial API endpoint
         $base_server_uri = "<%= Mixlib::Install::Dist::TRIAL_API_ENDPOINT %>"
       }

--- a/lib/mixlib/install/script_generator.rb
+++ b/lib/mixlib/install/script_generator.rb
@@ -240,7 +240,7 @@ module Mixlib
         # Use custom base_url if provided, otherwise determine from license type
         endpoint_base = if @base_url
                           @base_url
-                        elsif license_id.start_with?("free-", "trial-")
+                        elsif license_id.start_with?("trial-")
                           Mixlib::Install::Dist::TRIAL_API_ENDPOINT
                         else
                           Mixlib::Install::Dist::COMMERCIAL_API_ENDPOINT
@@ -259,7 +259,7 @@ module Mixlib
           # Use custom base_url if provided, otherwise determine from license type
           endpoint_base = if @base_url
                             @base_url
-                          elsif license_id.start_with?("free-", "trial-")
+                          elsif license_id.start_with?("trial-")
                             Mixlib::Install::Dist::TRIAL_API_ENDPOINT
                           else
                             Mixlib::Install::Dist::COMMERCIAL_API_ENDPOINT

--- a/spec/unit/mixlib/install/backend/package_router_spec.rb
+++ b/spec/unit/mixlib/install/backend/package_router_spec.rb
@@ -109,22 +109,22 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
     end
   end
 
-  context "for trial API with free- license_id" do
+  context "for commercial API with free- license_id" do
     let(:channel) { :stable }
     let(:product_name) { "chef" }
     let(:product_version) { "18.0.0" }
     let(:license_id) { "free-abc-def-123" }
 
-    it "uses trial API endpoint" do
-      expect(package_router.endpoint).to eq Mixlib::Install::Dist::TRIAL_API_ENDPOINT
+    it "uses commercial API endpoint" do
+      expect(package_router.endpoint).to eq Mixlib::Install::Dist::COMMERCIAL_API_ENDPOINT
     end
 
-    it "detects trial API usage" do
-      expect(package_router.use_trial_api?).to be true
+    it "does not detect trial API usage" do
+      expect(package_router.use_trial_api?).to be false
     end
 
-    it "does not detect commercial API usage" do
-      expect(package_router.use_commercial_api?).to be false
+    it "detects commercial API usage" do
+      expect(package_router.use_commercial_api?).to be true
     end
 
     it "detects licensed API usage" do
@@ -294,7 +294,7 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
     let(:channel) { :current }
     let(:product_name) { "chef-ice" }
     let(:product_version) { "19.1.151" }
-    let(:license_id) { "free-trial-xyz-123" }
+    let(:license_id) { "trial-xyz-123" }
     let(:platform) { "ubuntu" }
     let(:platform_version) { "20.04" }
     let(:architecture) { "x86_64" }

--- a/spec/unit/mixlib/install/backend_spec.rb
+++ b/spec/unit/mixlib/install/backend_spec.rb
@@ -205,7 +205,7 @@ context "Mixlib::Install::Backend", :vcr do
     end
   end
 
-  context "with free- license_id for trial API" do
+  context "with free- license_id for commercial API" do
     let(:product_name) { "chef" }
     let(:channel) { :stable }
     let(:product_version) { :latest }
@@ -224,11 +224,11 @@ context "Mixlib::Install::Backend", :vcr do
       expect(info_with_trial_license.options.license_id).to eq license_id
     end
 
-    it "uses trial API backend" do
+    it "uses commercial API backend (free- is not trial)" do
       backend = Mixlib::Install::Backend.backend(info_with_trial_license.options)
-      expect(backend.use_trial_api?).to be true
-      expect(backend.use_commercial_api?).to be false
-      expect(backend.endpoint).to eq Mixlib::Install::Dist::TRIAL_API_ENDPOINT
+      expect(backend.use_trial_api?).to be false
+      expect(backend.use_commercial_api?).to be true
+      expect(backend.endpoint).to eq Mixlib::Install::Dist::COMMERCIAL_API_ENDPOINT
     end
   end
 

--- a/spec/unit/mixlib/install/dist_spec.rb
+++ b/spec/unit/mixlib/install/dist_spec.rb
@@ -21,12 +21,12 @@ require "mixlib/install/dist"
 describe Mixlib::Install::Dist do
   describe ".trial_license?" do
     context "with free- prefix" do
-      it "returns true for free-trial-123" do
-        expect(Mixlib::Install::Dist.trial_license?("free-trial-123")).to be true
+      it "returns false for free-trial-123 (free- uses commercial API)" do
+        expect(Mixlib::Install::Dist.trial_license?("free-trial-123")).to be false
       end
 
-      it "returns true for free-abc-xyz" do
-        expect(Mixlib::Install::Dist.trial_license?("free-abc-xyz")).to be true
+      it "returns false for free-abc-xyz (free- uses commercial API)" do
+        expect(Mixlib::Install::Dist.trial_license?("free-abc-xyz")).to be false
       end
     end
 
@@ -83,8 +83,8 @@ describe Mixlib::Install::Dist do
     end
 
     context "with trial license" do
-      it "returns false for free-trial-123" do
-        expect(Mixlib::Install::Dist.commercial_license?("free-trial-123")).to be false
+      it "returns true for free-trial-123 (free- uses commercial API)" do
+        expect(Mixlib::Install::Dist.commercial_license?("free-trial-123")).to be true
       end
 
       it "returns false for trial-xyz-456" do

--- a/spec/unit/mixlib/install/generator_spec.rb
+++ b/spec/unit/mixlib/install/generator_spec.rb
@@ -148,16 +148,16 @@ context "Mixlib::Install::Generator", :vcr do
         expect(install_script).to include("license_id=free-trial-abc-123")
       end
 
-      it "uses trial API in metadata fetch" do
-        expect(install_script).to include("https://chefdownload-trial.chef.io")
+      it "uses commercial API in metadata fetch (free- is not trial)" do
+        expect(install_script).to include("https://chefdownload-commercial.chef.io")
       end
 
-      it "includes JSON parsing logic for trial API" do
+      it "includes JSON parsing logic for licensed API" do
         expect(install_script).to include("sed -n 's/.*\"url\":\"\\([^\"]*\\)\".*/\\1/p'")
         expect(install_script).to include("sed -n 's/.*\"sha256\":\"\\([^\"]*\\)\".*/\\1/p'")
       end
 
-      it "sets use_content_disposition flag for trial API" do
+      it "sets use_content_disposition flag for licensed API" do
         expect(install_script).to include("use_content_disposition=\"true\"")
       end
 
@@ -340,7 +340,7 @@ context "Mixlib::Install::Generator", :vcr do
     context "chef-ice with trial API" do
       let(:add_options) do
         {
-          license_id: "free-trial-xyz-123",
+          license_id: "trial-xyz-123",
         }
       end
 
@@ -504,11 +504,11 @@ context "Mixlib::Install::Generator", :vcr do
           expect(install_script).to match(/Install-Project -project #{options[:product_name]} -version .* -channel #{options[:channel]} -license_id free-trial-789\n/)
         end
 
-        it "uses trial API in metadata fetch" do
-          expect(install_script).to include("https://chefdownload-trial.chef.io")
+        it "uses commercial API in metadata fetch (free- is not trial)" do
+          expect(install_script).to include("https://chefdownload-commercial.chef.io")
         end
 
-        it "includes JSON parsing logic for trial API" do
+        it "includes JSON parsing logic for licensed API" do
           expect(install_script).to include("ConvertFrom-Json")
           expect(install_script).to include("$json.url")
           expect(install_script).to include("$json.sha256")
@@ -631,7 +631,7 @@ context "Mixlib::Install::Generator", :vcr do
           {
             product_name: "chef-ice",
             shell_type: :ps1,
-            license_id: "free-trial-xyz-123",
+            license_id: "trial-xyz-123",
           }
         end
 

--- a/spec/unit/mixlib/install/options_spec.rb
+++ b/spec/unit/mixlib/install/options_spec.rb
@@ -178,44 +178,28 @@ context "Mixlib::Install::Options" do
   context "for trial API defaults" do
     let(:product_name) { "chef" }
 
-    context "with free- license_id" do
+    context "with free- license_id (uses commercial API, no restrictions)" do
       let(:license_id) { "free-trial-abc-123" }
 
-      it "defaults to stable channel when current channel is specified" do
+      it "does not default channel (free- uses commercial API)" do
         expect do
           mi = Mixlib::Install.new(product_name: product_name, channel: :current, license_id: license_id)
-          expect(mi.options.channel).to eq :stable
-        end.to output(/WARNING: Trial API only supports 'stable' channel. Changing from 'current' to 'stable'/).to_stderr
-      end
-
-      it "defaults to latest version when specific version is specified" do
-        expect do
-          mi = Mixlib::Install.new(product_name: product_name, channel: :stable, product_version: "15.0.0", license_id: license_id)
-          expect(mi.options.product_version).to eq :latest
-        end.to output(/WARNING: Trial API only supports 'latest' version. Changing from '15.0.0' to 'latest'/).to_stderr
-      end
-
-      it "defaults both channel and version with two warnings" do
-        expect do
-          mi = Mixlib::Install.new(product_name: product_name, channel: :unstable, product_version: "14.5.1", license_id: license_id)
-          expect(mi.options.channel).to eq :stable
-          expect(mi.options.product_version).to eq :latest
-        end.to output(/WARNING: Trial API only supports 'stable' channel.*WARNING: Trial API only supports 'latest' version/m).to_stderr
-      end
-
-      it "does not warn when stable channel and latest version are already set" do
-        expect do
-          mi = Mixlib::Install.new(product_name: product_name, channel: :stable, product_version: :latest, license_id: license_id)
-          expect(mi.options.channel).to eq :stable
-          expect(mi.options.product_version).to eq :latest
+          expect(mi.options.channel).to eq :current
         end.not_to output.to_stderr
       end
 
-      it "does not warn when stable channel and latest version string are already set" do
+      it "does not default version (free- uses commercial API)" do
         expect do
-          mi = Mixlib::Install.new(product_name: product_name, channel: :stable, product_version: "latest", license_id: license_id)
-          expect(mi.options.channel).to eq :stable
-          expect(mi.options.product_version).to eq "latest"
+          mi = Mixlib::Install.new(product_name: product_name, channel: :stable, product_version: "15.0.0", license_id: license_id)
+          expect(mi.options.product_version).to eq "15.0.0"
+        end.not_to output.to_stderr
+      end
+
+      it "allows any channel without warnings" do
+        expect do
+          mi = Mixlib::Install.new(product_name: product_name, channel: :unstable, product_version: "14.5.1", license_id: license_id)
+          expect(mi.options.channel).to eq :unstable
+          expect(mi.options.product_version).to eq "14.5.1"
         end.not_to output.to_stderr
       end
     end

--- a/spec/unit/mixlib/install/script_generator_spec.rb
+++ b/spec/unit/mixlib/install/script_generator_spec.rb
@@ -267,10 +267,10 @@ describe Mixlib::Install::ScriptGenerator do
           expect(out).to include('chef_omnibus_url="https://chefdownload-trial.chef.io/install.sh?license_id=trial-abc123"')
         end
 
-        it "uses trial URL for free licenses" do
+        it "uses commercial URL for free licenses (free- uses commercial API)" do
           installer.license_id = "free-xyz789"
           out = installer.install_command
-          expect(out).to include('chef_omnibus_url="https://chefdownload-trial.chef.io/install.sh?license_id=free-xyz789"')
+          expect(out).to include('chef_omnibus_url="https://chefdownload-commercial.chef.io/install.sh?license_id=free-xyz789"')
         end
       end
 
@@ -346,9 +346,9 @@ describe Mixlib::Install::ScriptGenerator do
       context "with free license_id" do
         before { installer.license_id = "free-test123" }
 
-        it "returns trial URL with license_id" do
+        it "returns commercial URL with license_id (free- uses commercial API)" do
           url = installer.send(:omnibus_url_for_license)
-          expect(url).to eq("https://chefdownload-trial.chef.io/install.sh?license_id=free-test123")
+          expect(url).to eq("https://chefdownload-commercial.chef.io/install.sh?license_id=free-test123")
         end
       end
 

--- a/spec/unit/mixlib/install_spec.rb
+++ b/spec/unit/mixlib/install_spec.rb
@@ -204,26 +204,26 @@ context "Mixlib::Install" do
       end
     end
 
-    context "with trial license_id" do
+    context "with free- license_id (commercial API, no restrictions)" do
       let(:license_id) { "free-trial-abc-123" }
 
-      it "defaults channel to stable with warning" do
+      it "does not default channel (free- uses commercial API)" do
         expect do
           options = { license_id: license_id, channel: :current }
           script = Mixlib::Install.install_sh(options)
           expect(script).to include('license_id="free-trial-abc-123"')
-        end.to output(/WARNING: Trial API only supports 'stable' channel/).to_stderr
+        end.not_to output.to_stderr
       end
 
-      it "defaults version to latest with warning" do
+      it "does not default version (free- uses commercial API)" do
         expect do
           options = { license_id: license_id, version: "18.5.0" }
           script = Mixlib::Install.install_sh(options)
           expect(script).to include('license_id="free-trial-abc-123"')
-        end.to output(/WARNING: Trial API only supports 'latest' version/).to_stderr
+        end.not_to output.to_stderr
       end
 
-      it "does not warn when stable and latest already set" do
+      it "allows any channel and version without warnings" do
         expect do
           options = { license_id: license_id, channel: :stable, version: :latest }
           script = Mixlib::Install.install_sh(options)


### PR DESCRIPTION
## Description

Chef licenses prefixed with free- are allowed on the commercial api without restriction of version or channel to use. Trial prefix is relegated to only use trial api endpoint and is restricted to stable channel/latest version of products.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
