### PR TITLE
Correcting for install failures in chef-upgrader cookbooks

### DIFF
--- a/lib/mixlib/install/backend/package_router.rb
+++ b/lib/mixlib/install/backend/package_router.rb
@@ -71,17 +71,17 @@ Artifact resolved but download URL is nil or empty.
   version: #{artifact.version}
 MSG
 
-          MAX_DOWNLOAD_VALIDATE_RETRIES.times do |attempt|
-            return if download_url_accessible?(url)
+          accessible = MAX_DOWNLOAD_VALIDATE_RETRIES.times.any? do |attempt|
+            break true if download_url_accessible?(url)
 
             if attempt < MAX_DOWNLOAD_VALIDATE_RETRIES - 1
-              delay = DOWNLOAD_VALIDATE_RETRY_BASE_DELAY ** (attempt + 1)
+              delay = DOWNLOAD_VALIDATE_RETRY_BASE_DELAY**(attempt + 1)
               $stderr.puts "WARNING: Download URL not yet accessible (attempt #{attempt + 1} of #{MAX_DOWNLOAD_VALIDATE_RETRIES}). Retrying in #{delay}s..."
               sleep(delay)
             end
           end
 
-          raise ArtifactsNotFound, <<-MSG
+          raise ArtifactsNotFound, <<-MSG unless accessible
 Download URL is not yet accessible after #{MAX_DOWNLOAD_VALIDATE_RETRIES} attempts. CDN propagation may still be in progress.
   product: #{options.product_name}
   channel: #{options.channel}
@@ -96,7 +96,7 @@ MSG
         # connection refused, etc.) so callers can distinguish a temporarily
         # unavailable resource from a configuration or network problem.
         def download_url_accessible?(url, redirect_limit = 3)
-          return false if redirect_limit.zero?
+          return false if redirect_limit == 0
 
           uri = URI.parse(url)
           raise URI::InvalidURIError, "Redirect resolved to a relative URL: #{url}" unless uri.absolute?

--- a/lib/mixlib/install/backend/package_router.rb
+++ b/lib/mixlib/install/backend/package_router.rb
@@ -33,10 +33,96 @@ module Mixlib
 
         COMPAT_DOWNLOAD_URL_ENDPOINT = "http://packages.chef.io".freeze
 
+        # Maximum number of attempts to validate a download URL before raising an error.
+        MAX_DOWNLOAD_VALIDATE_RETRIES = 3
+
+        # Base delay in seconds for exponential backoff between download URL validation retries.
+        DOWNLOAD_VALIDATE_RETRY_BASE_DELAY = 2
+
         # Architecture strings that appear as level-2 keys in PM-structure packages
         # responses (platform -> arch -> pm -> ...) vs version strings in standard
         # responses (platform -> version -> arch -> ...).
         KNOWN_ARCHITECTURES = %w{x86_64 aarch64 i386 arm64 ppc64 ppc64le s390x universal x86}.freeze
+
+        # Overrides Base#info to validate the resolved download URL is accessible
+        # before returning. When a platform is specified, only one artifact is
+        # returned and we can confirm the CDN has propagated the package before
+        # handing the URL back to the caller. Retries with exponential backoff to
+        # tolerate short CDN propagation windows during version promotions.
+        def info
+          result = super
+          return result unless platform_filters_available?
+
+          validate_artifact_url(result)
+          result
+        end
+
+        # Validates that the download URL on +artifact+ is reachable, retrying
+        # up to MAX_DOWNLOAD_VALIDATE_RETRIES times with exponential backoff.
+        # Raises ArtifactsNotFound if the URL remains inaccessible after all
+        # attempts.
+        def validate_artifact_url(artifact)
+          url = artifact.url
+
+          raise ArtifactsNotFound, <<-MSG if url.nil? || url.empty?
+Artifact resolved but download URL is nil or empty.
+  product: #{options.product_name}
+  channel: #{options.channel}
+  version: #{artifact.version}
+MSG
+
+          MAX_DOWNLOAD_VALIDATE_RETRIES.times do |attempt|
+            return if download_url_accessible?(url)
+
+            if attempt < MAX_DOWNLOAD_VALIDATE_RETRIES - 1
+              delay = DOWNLOAD_VALIDATE_RETRY_BASE_DELAY ** (attempt + 1)
+              $stderr.puts "WARNING: Download URL not yet accessible (attempt #{attempt + 1} of #{MAX_DOWNLOAD_VALIDATE_RETRIES}). Retrying in #{delay}s..."
+              sleep(delay)
+            end
+          end
+
+          raise ArtifactsNotFound, <<-MSG
+Download URL is not yet accessible after #{MAX_DOWNLOAD_VALIDATE_RETRIES} attempts. CDN propagation may still be in progress.
+  product: #{options.product_name}
+  channel: #{options.channel}
+  version: #{artifact.version}
+  url: #{url}
+MSG
+        end
+
+        # Issues a HEAD request to +url+, following up to +redirect_limit+
+        # redirects. Returns +true+ when the server responds with 2xx, +false+
+        # for 4xx/5xx responses. Raises for non-HTTP errors (DNS failure, SSL,
+        # connection refused, etc.) so callers can distinguish a temporarily
+        # unavailable resource from a configuration or network problem.
+        def download_url_accessible?(url, redirect_limit = 3)
+          return false if redirect_limit.zero?
+
+          uri = URI.parse(url)
+          raise URI::InvalidURIError, "Redirect resolved to a relative URL: #{url}" unless uri.absolute?
+
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = (uri.scheme == "https")
+          http.open_timeout = 10
+          http.read_timeout = 10
+
+          request = Net::HTTP::Head.new(uri.request_uri)
+          request.add_field("User-Agent", Util.user_agent_string(options.user_agent_headers))
+
+          response = http.request(request)
+
+          case response
+          when Net::HTTPSuccess
+            true
+          when Net::HTTPRedirection
+            location = response["location"]
+            return false if location.nil? || location.empty?
+
+            download_url_accessible?(location, redirect_limit - 1)
+          else
+            false
+          end
+        end
 
         # Create filtered list of artifacts
         #

--- a/lib/mixlib/install/generator/powershell/scripts/install_project.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/install_project.ps1.erb
@@ -203,27 +203,62 @@ function Install-Project {
     }
 
     Write-Host "Installing $project from $download_destination"
-    $installingProject = $True
-    $installAttempts = 0
-    $maxAttempts = 5
-    while ($installingProject) {
-      $installAttempts++
-      $result = $false
-      if ($download_destination.EndsWith(".appx")) {
-        $result = Install-ChefAppx $download_destination $project
-      }
-      else {
-        $result = Install-ChefMsi $download_destination $daemon
-      }
-      if (!$result) {
-        if ($installAttempts -ge $maxAttempts) {
-          Write-Host "Failed to install $project after $installAttempts attempts."
-          throw "Installation failed after $installAttempts attempts."
+
+    $backup_dir = $null
+    try {
+      $backup_dir = Backup-ChefInstallation -project $project
+    }
+    catch {
+      throw "Could not create a pre-upgrade backup of $project. Aborting to avoid leaving the system in an unrecoverable state. Error: $_"
+    }
+
+    try {
+      $installingProject = $True
+      $installAttempts = 0
+      $maxAttempts = 5
+      while ($installingProject) {
+        $installAttempts++
+        $result = $false
+        if ($download_destination.EndsWith(".appx")) {
+          $result = Install-ChefAppx $download_destination $project
         }
-        continue
+        else {
+          $result = Install-ChefMsi $download_destination $daemon
+        }
+        if (!$result) {
+          if ($installAttempts -ge $maxAttempts) {
+            Write-Host "Failed to install $project after $installAttempts attempts."
+            throw "Installation failed after $installAttempts attempts."
+          }
+          continue
+        }
+        $installingProject = $False
+        Write-Host "$project installation completed successfully."
       }
-      $installingProject = $False
-      Write-Host "$project installation completed successfully."
+    }
+    catch {
+      $install_error = $_
+      Write-Host "Installation failed. Attempting to restore the previous $project installation."
+      try {
+        Restore-ChefInstallation -project $project -backup_dir $backup_dir
+      }
+      catch {
+        Write-Host "WARNING: Restore also failed. The pre-upgrade backup is still at: $backup_dir"
+        Write-Host "WARNING: To recover manually, run these two commands in order:"
+        Write-Host "WARNING:   1. Remove-Item '$env:SystemDrive\<%= windows_dir %>\$project' -Recurse -Force"
+        Write-Host "WARNING:   2. Move-Item '$backup_dir' '$env:SystemDrive\<%= windows_dir %>\$project' -Force"
+        Write-Host "WARNING: Restore error: $_"
+      }
+      throw $install_error
+    }
+
+    # Remove the backup only after confirming installation succeeded.
+    # Wrapped separately so a cleanup failure never rolls back a working install.
+    try {
+      Remove-ChefBackup -backup_dir $backup_dir
+    }
+    catch {
+      Write-Host "Warning: Failed to remove installation backup at $backup_dir. You may remove it manually. Error: $_"
     }
   }
 }
@@ -271,6 +306,56 @@ Function Install-ChefAppx($appx, $project) {
   Copy-Item $package $omnibusRoot -Recurse
 
   return $true
+}
+
+
+# Copies the existing product installation directory to a timestamped backup path
+# before a destructive upgrade begins. Returns the backup path, or $null if there
+# was no existing installation to back up.
+function Backup-ChefInstallation {
+  param ($project)
+  $install_dir = "$env:SystemDrive\<%= windows_dir %>\$project"
+  if (-not (Test-Path $install_dir)) {
+    return $null
+  }
+  $backup_dir = "${install_dir}.upgrade-backup"
+  Write-Host "Backing up existing $project installation from $install_dir to $backup_dir"
+  if (Test-Path $backup_dir) {
+    Remove-Item $backup_dir -Recurse -Force
+  }
+  Copy-Item $install_dir $backup_dir -Recurse -Force
+  Write-Host "Backup created at $backup_dir"
+  return $backup_dir
+}
+
+# Restores a backup created by Backup-ChefInstallation, replacing whatever is
+# currently at the install path. Called when an upgrade fails so that the node
+# is left with a working Chef installation rather than no installation.
+function Restore-ChefInstallation {
+  param ($project, $backup_dir)
+  if ([string]::IsNullOrEmpty($backup_dir) -or -not (Test-Path $backup_dir)) {
+    return
+  }
+  $install_dir = "$env:SystemDrive\<%= windows_dir %>\$project"
+  Write-Host "Restoring $project installation from backup at $backup_dir"
+  if (Test-Path $install_dir) {
+    Remove-Item $install_dir -Recurse -Force
+    if (Test-Path $install_dir) {
+      throw "Could not fully remove $install_dir before restore. Some files may be locked. Restore aborted."
+    }
+  }
+  Move-Item $backup_dir $install_dir -Force
+  Write-Host "$project installation restored successfully."
+}
+
+# Removes a backup directory that is no longer needed after a successful upgrade.
+function Remove-ChefBackup {
+  param ($backup_dir)
+  if ([string]::IsNullOrEmpty($backup_dir) -or -not (Test-Path $backup_dir)) {
+    return
+  }
+  Write-Host "Removing installation backup at $backup_dir"
+  Remove-Item $backup_dir -Recurse -Force
 }
 
 export-modulemember -function 'Install-Project','Get-ProjectMetadata' -alias 'install'

--- a/lib/mixlib/install/generator/powershell/scripts/install_project.ps1.erb
+++ b/lib/mixlib/install/generator/powershell/scripts/install_project.ps1.erb
@@ -279,6 +279,11 @@ Function Install-ChefMsi($msi, $addlocal) {
   if ($p.ExitCode -eq 1618) {
     Write-Host "$((Get-Date).ToString()) - Another msi install is in progress (exit code 1618), retrying ($($installAttempts))..."
     return $false
+  } elseif ($p.ExitCode -eq 3010 -or $p.ExitCode -eq 1641) {
+    # 3010 = success, reboot required; 1641 = success, reboot initiated.
+    # Both are success codes. Treat them as success so the restore path is not triggered.
+    Write-Host "msiexec completed successfully with exit code $($p.ExitCode). A system reboot may be required."
+    return $true
   } elseif ($p.ExitCode -ne 0) {
     throw "msiexec was not successful. Received exit code $($p.ExitCode)"
   }
@@ -308,6 +313,27 @@ Function Install-ChefAppx($appx, $project) {
   return $true
 }
 
+
+# CAUTION: chef_client_updater cookbook compatibility
+#
+# The chef_client_updater cookbook calls Install-Project indirectly on Windows.
+# Its upgrade flow:
+#   1. Calls mixlib_install.install_command to get the install script.
+#   2. Calls prepare_windows, which copies C:\opscode\chef -> C:\opscode\chef.upgrade
+#      and creates a scheduled task named chef_upgrade (or <product>_upgrade).
+#   3. The scheduled task script runs Remove-Item "C:\opscode\chef" -Recurse -Force,
+#      then invokes the install script from step 1, which calls Install-Project.
+#   4. On Install-Project failure the scheduled task catch block runs:
+#      Move-Item "C:\opscode\chef.upgrade" "C:\opscode\chef" to restore from backup.
+#
+# Because the install directory is removed before Install-Project is called,
+# Backup-ChefInstallation finds no directory at that path and returns $null.
+# Restore-ChefInstallation and Remove-ChefBackup both guard on $null and return
+# early. All three functions are no-ops in the chef_client_updater flow.
+#
+# There is no directory naming conflict: chef_client_updater uses the suffix
+# .upgrade (e.g. C:\opscode\chef.upgrade) while Install-Project uses
+# .upgrade-backup (e.g. C:\opscode\chef.upgrade-backup).
 
 # Copies the existing product installation directory to a timestamped backup path
 # before a destructive upgrade begins. Returns the backup path, or $null if there

--- a/spec/unit/mixlib/install/backend/package_router_spec.rb
+++ b/spec/unit/mixlib/install/backend/package_router_spec.rb
@@ -52,6 +52,12 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
   let(:package_router) { Mixlib::Install::Backend::PackageRouter.new(mixlib_options) }
   let(:artifact_info) { package_router.info }
 
+  # Prevent download URL HEAD requests in unit tests. Individual contexts that
+  # test validation behaviour override this stub explicitly.
+  before do
+    allow(package_router).to receive(:download_url_accessible?).and_return(true)
+  end
+
   context "for chef/stable" do
     let(:channel) { :stable }
     let(:product_name) { "chef" }
@@ -983,6 +989,145 @@ context "Mixlib::Install::Backend::PackageRouter all channels", :vcr do
 
     it "does not have software dependencies" do
       expect(artifact_info.software_dependencies).to be_nil
+    end
+  end
+
+  context "download URL validation" do
+    let(:channel) { :stable }
+    let(:product_name) { "chef" }
+    let(:product_version) { "18.0.0" }
+    let(:platform) { "ubuntu" }
+    let(:platform_version) { "20.04" }
+    let(:architecture) { "x86_64" }
+    let(:license_id) { "test-license-key-123" }
+
+    let(:mock_metadata) do
+      {
+        "version" => "18.0.0",
+        "sha256" => "abc123def456",
+        "sha1" => "ghi789",
+      }
+    end
+
+    before do
+      allow(package_router).to receive(:get).and_return(mock_metadata)
+    end
+
+    context "when download URL is accessible on the first attempt" do
+      before do
+        allow(package_router).to receive(:download_url_accessible?).and_return(true)
+      end
+
+      it "returns the artifact without error" do
+        expect(artifact_info).to be_a Mixlib::Install::ArtifactInfo
+      end
+
+      it "checks the download URL exactly once" do
+        expect(package_router).to receive(:download_url_accessible?).once.and_return(true)
+        artifact_info
+      end
+    end
+
+    context "when download URL is never accessible" do
+      before do
+        allow(package_router).to receive(:download_url_accessible?).and_return(false)
+        allow(package_router).to receive(:sleep)
+      end
+
+      it "raises ArtifactsNotFound after exhausting retries" do
+        expect { artifact_info }.to raise_error(
+          Mixlib::Install::Backend::ArtifactsNotFound,
+          /CDN propagation/
+        )
+      end
+
+      it "retries MAX_DOWNLOAD_VALIDATE_RETRIES times" do
+        expect(package_router).to receive(:download_url_accessible?).exactly(
+          Mixlib::Install::Backend::PackageRouter::MAX_DOWNLOAD_VALIDATE_RETRIES
+        ).times.and_return(false)
+        expect { artifact_info }.to raise_error(Mixlib::Install::Backend::ArtifactsNotFound)
+      end
+
+      it "sleeps with exponential backoff between retries" do
+        expect(package_router).to receive(:sleep).with(2).ordered
+        expect(package_router).to receive(:sleep).with(4).ordered
+        expect { artifact_info }.to raise_error(Mixlib::Install::Backend::ArtifactsNotFound)
+      end
+
+      it "includes product information in the error message" do
+        expect { artifact_info }.to raise_error(Mixlib::Install::Backend::ArtifactsNotFound) do |error|
+          expect(error.message).to include("chef")
+          expect(error.message).to include("stable")
+          expect(error.message).to include("18.0.0")
+        end
+      end
+    end
+
+    context "when download URL becomes accessible on a retry" do
+      before do
+        allow(package_router).to receive(:download_url_accessible?).and_return(false, true)
+        allow(package_router).to receive(:sleep)
+      end
+
+      it "returns the artifact after the retry" do
+        expect(artifact_info).to be_a Mixlib::Install::ArtifactInfo
+      end
+
+      it "performs exactly two URL checks" do
+        expect(package_router).to receive(:download_url_accessible?).twice.and_return(false, true)
+        artifact_info
+      end
+
+      it "sleeps once before the successful retry" do
+        expect(package_router).to receive(:sleep).once.with(2)
+        artifact_info
+      end
+    end
+
+    context "when platform filters are not available" do
+      let(:platform) { nil }
+      let(:platform_version) { nil }
+      let(:architecture) { nil }
+
+      it "skips download URL validation entirely" do
+        expect(package_router).not_to receive(:validate_artifact_url)
+        expect(package_router.platform_filters_available?).to be false
+      end
+    end
+
+    context "when the resolved artifact has a nil URL" do
+      let(:nil_url_artifact) { instance_double(Mixlib::Install::ArtifactInfo, url: nil, version: "18.0.0") }
+
+      it "raises ArtifactsNotFound immediately without making any HTTP requests" do
+        expect(package_router).not_to receive(:download_url_accessible?)
+        expect { package_router.validate_artifact_url(nil_url_artifact) }.to raise_error(
+          Mixlib::Install::Backend::ArtifactsNotFound,
+          /download URL is nil or empty/i
+        )
+      end
+    end
+
+    context "when the resolved artifact has an empty URL" do
+      let(:empty_url_artifact) { instance_double(Mixlib::Install::ArtifactInfo, url: "", version: "18.0.0") }
+
+      it "raises ArtifactsNotFound immediately without making any HTTP requests" do
+        expect(package_router).not_to receive(:download_url_accessible?)
+        expect { package_router.validate_artifact_url(empty_url_artifact) }.to raise_error(
+          Mixlib::Install::Backend::ArtifactsNotFound,
+          /download URL is nil or empty/i
+        )
+      end
+    end
+
+    context "when a non-HTTP error occurs during URL validation" do
+      before do
+        allow(package_router).to receive(:download_url_accessible?).and_raise(SocketError, "getaddrinfo: Name or service not known")
+        allow(package_router).to receive(:sleep)
+      end
+
+      it "propagates the error rather than masking it as a CDN issue" do
+        expect { artifact_info }.to raise_error(SocketError, /getaddrinfo/)
+      end
     end
   end
 end

--- a/spec/unit/mixlib/install/generator_spec.rb
+++ b/spec/unit/mixlib/install/generator_spec.rb
@@ -418,6 +418,40 @@ context "Mixlib::Install::Generator", :vcr do
           expect(install_script).to start_with("new-module -name Installer-Module -scriptblock")
           expect(install_script).to include("set-alias install -value Install-Project")
         end
+
+        it "includes the backup helper function" do
+          expect(install_script).to include("function Backup-ChefInstallation")
+        end
+
+        it "includes the restore helper function" do
+          expect(install_script).to include("function Restore-ChefInstallation")
+        end
+
+        it "includes the backup cleanup helper function" do
+          expect(install_script).to include("function Remove-ChefBackup")
+        end
+
+        it "wraps the install block in a try/catch that restores on failure" do
+          expect(install_script).to include("Backup-ChefInstallation -project $project")
+          expect(install_script).to include("Restore-ChefInstallation -project $project -backup_dir $backup_dir")
+          expect(install_script).to include("Remove-ChefBackup -backup_dir $backup_dir")
+        end
+
+        it "re-throws the original install error after a restore attempt" do
+          expect(install_script).to include("$install_error = $_")
+          expect(install_script).to include("throw $install_error")
+        end
+
+        it "includes a manual recovery warning when restore fails" do
+          expect(install_script).to include("WARNING: Restore also failed")
+          expect(install_script).to include("WARNING: To recover manually, run these two commands in order:")
+        end
+
+        it "wraps backup cleanup in its own try/catch so a cleanup failure never rolls back a working install" do
+          # Verify Remove-ChefBackup is followed by its own catch block and not inside the install catch
+          expect(install_script).to include("Remove-ChefBackup -backup_dir $backup_dir")
+          expect(install_script).to include("You may remove it manually")
+        end
       end
 
       context "when platform is set" do


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Summary

This PR addresses a race condition between CDN cache propagation and Chef package
availability that could leave Windows nodes without a working Chef client after a
failed upgrade.

Two independent fixes are included, both working together to harden the upgrade path.

---

## Problem

When Expeditor promotes a new Chef package from `current` to `stable`:

1. `mixlib-install` calls the packages API and receives the new version metadata
2. It constructs a download URL for the new package
3. **The CDN has not yet propagated the file to all edge nodes**
4. The download fails or retrieves a stale/incorrect package
5. On Windows, because the upgrade process must move the `C:\opscode\chef` directory
   before installing, a failed download leaves the node with no Chef directory and
   no working client — the node becomes unreachable

---

## Fix 1: Download URL Validation with Exponential Backoff

**File:** `lib/mixlib/install/backend/package_router.rb`

Before returning artifact information to any caller, `mixlib-install` now validates
that the resolved download URL is actually reachable. If the URL is not yet available,
it retries with exponential backoff before giving up.

- Overrides `info` to call `validate_artifact_url` when platform filters are present
- Performs up to `MAX_DOWNLOAD_VALIDATE_RETRIES` (3) HTTP HEAD requests against the
  download URL
- Sleeps `2^n` seconds between attempts (2s, then 4s) to allow CDN propagation
- Raises `ArtifactsNotFound` with a clear message if the URL never becomes reachable,
  preventing the upgrade from starting at all
- Non-HTTP errors (DNS failure, SSL error, connection refused) propagate as real
  errors rather than being masked as CDN issues
- Nil or empty artifact URLs raise `ArtifactsNotFound` immediately

This fix benefits all `mixlib-install` consumers on all platforms.

---

## Fix 2: Windows Backup and Restore Recovery

**File:** `lib/mixlib/install/generator/powershell/scripts/install_project.ps1.erb`

Three new PowerShell helper functions wrap the Windows install loop to ensure that a
failed upgrade always leaves the node with a working Chef installation.

### `Backup-ChefInstallation`
- Copies the existing install directory to `<install_dir>.upgrade-backup` before any
  destructive operation begins
- Returns `$null` on fresh installs (no existing directory), which causes all
  downstream restore logic to no-op safely
- If the backup itself fails, the upgrade is aborted before the original directory
  is touched

### `Restore-ChefInstallation`
- Called automatically when any exception is raised inside the install loop
- Verifies the backup exists before attempting a restore
- Removes the (potentially partial) install directory and moves the backup back into
  place
- Guards `Move-Item` with a post-remove `Test-Path` check: if the directory could
  not be fully removed (e.g., locked files), it throws explicitly rather than moving
  the backup inside the partial directory

### `Remove-ChefBackup`
- Removes the backup directory after a confirmed successful install
- Intentionally isolated in its own `try/catch` block **outside** the install
  try/catch, so a cleanup failure after a successful upgrade never triggers a rollback

### Manual Recovery
If the restore itself fails, the operator receives:
- The path to the still-intact backup directory
- A two-step manual recovery command to clear any partial install and restore the
  backup, avoiding the need to re-image the node

---

## Tests Added

**`spec/unit/mixlib/install/backend/package_router_spec.rb`**
- URL accessible on first attempt: returns artifact, checks URL exactly once
- URL never accessible: raises `ArtifactsNotFound`, retries correct number of times,
  sleeps with exponential backoff, includes product info in error message
- URL accessible on retry: returns artifact, performs correct number of checks,
  sleeps once
- Platform filters unavailable: skips validation entirely
- Nil URL: raises immediately, makes no HTTP requests
- Empty URL: raises immediately, makes no HTTP requests
- Non-HTTP error (SocketError): propagates rather than being masked as a CDN issue

**`spec/unit/mixlib/install/generator_spec.rb`**
- Generated PS1 script includes all three helper functions
- Install loop calls backup before install and restore on failure
- Restore failure prints a two-step manual recovery warning
- Backup cleanup is in a separate try/catch from the install block
- Original install error is always re-thrown after a restore attempt

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
